### PR TITLE
Bug fix: Search box overlaps Guided Answers title on reducing width

### DIFF
--- a/.changeset/serious-buses-punch.md
+++ b/.changeset/serious-buses-punch.md
@@ -1,6 +1,6 @@
 ---
-'@sap/guided-answers-extension-webapp': minor
-'sap-guided-answers-extension': minor
+'@sap/guided-answers-extension-webapp': patch
+'sap-guided-answers-extension': patch
 ---
 
 Search bar overlap bug fixed

--- a/.changeset/serious-buses-punch.md
+++ b/.changeset/serious-buses-punch.md
@@ -1,0 +1,6 @@
+---
+'@sap/guided-answers-extension-webapp': minor
+'sap-guided-answers-extension': minor
+---
+
+Search bar overlap bug fixed

--- a/packages/webapp/src/webview/ui/components/App/App.scss
+++ b/packages/webapp/src/webview/ui/components/App/App.scss
@@ -68,7 +68,7 @@ h1 {
 
 .striped-list {
     padding-left: 0;
-    margin-top: 45px;
+    margin-top: 40px;
 }
 
 ul.striped-list > li:nth-of-type(odd) {

--- a/packages/webapp/src/webview/ui/components/Header/Header.scss
+++ b/packages/webapp/src/webview/ui/components/Header/Header.scss
@@ -41,14 +41,35 @@
             display: flex;
             align-items: center;
             margin-top: 40px;
-            width: 25%;
+            width: 33%;
+            min-width: 250px;
         }
         &__searchField {
             display: flex;
-            align-items: center;
+            align-items: start;
             flex-direction: column;
             margin-top: 40px;
-            width: 75%;
+            width: 66%;
+        }
+    }
+}
+
+@media only screen and (max-width: 625px) {
+    .guided-answer {
+        &__header {
+            &__logoAndTitle {
+                width: 50%;
+            }
+
+            &__sub {
+                align-items: start;
+                flex-direction: column;
+            }
+
+            &__searchField {
+                margin-top: 20px;
+                align-items: start;
+            }
         }
     }
 }


### PR DESCRIPTION
Related Issue: BUG- Search box overlaps Guided Answers title on reducing width

#109 

Description: Added media queries to make the search bar drop-down at smaller viewports

