### PR TITLE
feat: start ga command with node path

### DIFF
--- a/.changeset/dull-carpets-build.md
+++ b/.changeset/dull-carpets-build.md
@@ -1,0 +1,8 @@
+---
+'@sap/guided-answers-extension-core': minor
+'sap-guided-answers-extension': minor
+'@sap/guided-answers-extension-types': minor
+'@sap/guided-answers-extension-webapp': minor
+---
+
+Adding functionality to call Guided Answers command with node path 

--- a/docs/technical-information.md
+++ b/docs/technical-information.md
@@ -21,16 +21,23 @@ Here are some characteristics of the module
 - listens to messages/actions from UI and handles or dispatches them
 - uses module [`@sap/guided-answers-extension-core`](../packages/core/) to communicate with the Guided Answers REST API
 
-Command `SAP: Open Guided Answers` is registered to start the main screen which allows to search for Guided Answers. There is also a possibility to programmatically start Guided Answers from another extension with a particular Guided Answers tree id, e.g.
+Command `SAP: Open Guided Answers` is registered to start the main screen which allows to search for Guided Answers. There is also a possibility to programmatically start Guided Answers from another extension with a particular Guided Answers tree id, or a complete path to a node, e.g.
 
 ```typescript
 import { commands } from 'vscode';
 
+// (1) Call Guided Answers with a tree
 commands.executeCommand('sap.ux.guidedAnswer.openGuidedAnswer', { treeId: 3046 });
+
+// (2) Call Guided Answers with a tree and node path
+commands.executeCommand('sap.ux.guidedAnswer.openGuidedAnswer', { treeId: 3046, nodeIdPath: [45995, 45996, 46000] });
 ```
 
 The tree id can be captured from the Guide Answer's guide URL, e.g.:   
-`https://ga.support.sap.com/dtp/viewer/index.html#/tree/`**3046**`/actions/45995`
+`https://ga.support.sap.com/dtp/viewer/index.html#/tree/`**3046**`/actions/45995`.
+
+The first example will immediately show the Guided Answer tree 3046 and the first node 45995, the second example will navigate to a path including four steps, like: 
+https://ga.support.sap.com/dtp/viewer/index.html#/tree/3046/actions/45995:45996:45999:46000
 
 ### Module `@sap/guided-answers-extension-core` ([packages/core](../packages/core/)) 
 

--- a/packages/core/src/guided-answers-api.ts
+++ b/packages/core/src/guided-answers-api.ts
@@ -33,7 +33,12 @@ export function getGuidedAnswerApi(options?: APIOptions): GuidedAnswerAPI {
         getNodeById: async (id: GuidedAnswerNodeId): Promise<GuidedAnswerNode> =>
             enhanceNode(await getNodeById(apiHost, id), nodeEnhancements, htmlEnhancements),
         getTreeById: async (id: GuidedAnswerTreeId): Promise<GuidedAnswerTree> => getTreeById(apiHost, id),
-        getTrees: async (query?: string): Promise<GuidedAnswerTree[]> => getTrees(apiHost, query)
+        getTrees: async (query?: string): Promise<GuidedAnswerTree[]> => getTrees(apiHost, query),
+        getNodePath: async (nodeIdPath: GuidedAnswerNodeId[]): Promise<GuidedAnswerNode[]> => {
+            let nodes = await getNodePath(apiHost, nodeIdPath);
+            nodes = nodes.map((node) => enhanceNode(node, nodeEnhancements, htmlEnhancements));
+            return nodes;
+        }
     };
 }
 
@@ -144,4 +149,19 @@ function enhanceNode(
         }
     }
     return node;
+}
+
+/**
+ * Get an array of nodes from an array of node ids.
+ *
+ * @param host - Guided Answer API host
+ * @param nodeIdPath - node path as array of node ids
+ */
+async function getNodePath(host: string, nodeIdPath: GuidedAnswerNodeId[]): Promise<GuidedAnswerNode[]> {
+    const resolvedNodes: GuidedAnswerNode[] = [];
+    for (const nodeId of nodeIdPath) {
+        const node = await getNodeById(host, nodeId);
+        resolvedNodes.push(node);
+    }
+    return resolvedNodes;
 }

--- a/packages/core/test/__snapshots__/guided-answers-api.test.ts.snap
+++ b/packages/core/test/__snapshots__/guided-answers-api.test.ts.snap
@@ -70,7 +70,7 @@ Object {
 }
 `;
 
-exports[`Guided Answers Api: getNodePath() Get node path, node enhanced, should return enhanced list of nodes 1`] = `
+exports[`Guided Answers Api: getNodePath() Get node path, node enhanced, should return list of enhanced nodes 1`] = `
 Array [
   Object {
     "BODY": "<p>This is node Onehundredeleven</p>",

--- a/packages/core/test/__snapshots__/guided-answers-api.test.ts.snap
+++ b/packages/core/test/__snapshots__/guided-answers-api.test.ts.snap
@@ -69,3 +69,33 @@ Object {
   "TITLE": "Node",
 }
 `;
+
+exports[`Guided Answers Api: getNodePath() Get node path, node enhanced, should return enhanced list of nodes 1`] = `
+Array [
+  Object {
+    "BODY": "<p>This is node Onehundredeleven</p>",
+    "EDGES": Array [
+      Object {
+        "LABEL": "Next",
+        "ORD": 1,
+        "TARGET_NODE": 112,
+      },
+      Object {
+        "LABEL": "Somewhere else",
+        "ORD": 2,
+        "TARGET_NODE": 911,
+      },
+    ],
+    "NODE_ID": 111,
+    "QUESTION": "Where next",
+    "TITLE": "Onehundredeleven",
+  },
+  Object {
+    "BODY": "<p>This is node <span data-guided-answers-command-8d98638a0304b3f13b54d885dc542121=\\"%7B%22label%22%3A%22Command%20for%20Onehundredtwelve%22%2C%22description%22%3A%22Command%20to%20enhance%20node%20in%20path%22%2C%22icon%22%3A%22%22%2C%22exec%22%3A%7B%22cwd%22%3A%22%2F%22%2C%22arguments%22%3A%5B%22TEST%22%5D%7D%7D\\">Onehundredtwelve</span></p>",
+    "EDGES": Array [],
+    "NODE_ID": 112,
+    "QUESTION": "Nowhere else to go",
+    "TITLE": "Onehundredtwelve",
+  },
+]
+`;

--- a/packages/core/test/guided-answers-api.test.ts
+++ b/packages/core/test/guided-answers-api.test.ts
@@ -278,3 +278,66 @@ describe('Guided Answers Api: getNodeById()', () => {
         expect(result.COMMANDS).toEqual(options.enhancements.nodeEnhancements.map((ne) => ne.command));
     });
 });
+
+describe('Guided Answers Api: getNodePath()', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('Get node path, node enhanced, should return list of enhanced nodes', async () => {
+        // Mock setup
+        const nodes = [
+            {
+                NODE_ID: 111,
+                TITLE: 'Onehundredeleven',
+                BODY: '<p>This is node Onehundredeleven</p>',
+                QUESTION: 'Where next',
+                EDGES: [
+                    { LABEL: 'Next', TARGET_NODE: 112, ORD: 1 },
+                    { LABEL: 'Somewhere else', TARGET_NODE: 911, ORD: 2 }
+                ]
+            },
+            {
+                NODE_ID: 112,
+                TITLE: 'Onehundredtwelve',
+                BODY: '<p>This is node Onehundredtwelve</p>',
+                QUESTION: 'Nowhere else to go',
+                EDGES: []
+            }
+        ];
+
+        const options = {
+            enhancements: {
+                nodeEnhancements: [],
+                htmlEnhancements: [
+                    {
+                        text: 'Onehundredtwelve',
+                        command: {
+                            label: 'Command for Onehundredtwelve',
+                            description: `Command to enhance node in path`,
+                            icon: '',
+                            exec: {
+                                cwd: '/',
+                                arguments: ['TEST']
+                            }
+                        }
+                    }
+                ]
+            }
+        };
+        mockedAxios.get.mockImplementation((url: string) => {
+            const data = nodes.find((n) => url.endsWith(`/${n.NODE_ID}`));
+            if (data) {
+                return Promise.resolve({ data });
+            } else {
+                return Promise.reject('node not found');
+            }
+        });
+
+        // Test execution
+        const result = await getGuidedAnswerApi(options).getNodePath([111, 112]);
+
+        // Result check
+        expect(result).toMatchSnapshot();
+    });
+});

--- a/packages/ide-extension/esbuild.js
+++ b/packages/ide-extension/esbuild.js
@@ -1,43 +1,52 @@
 const { join } = require('path');
 const { copy } = require('esbuild-plugin-copy');
+
+const buildConfig = {
+    logLevel: 'info',
+    outfile: 'dist/extension-min.js',
+    entryPoints: [join(process.cwd(), 'src/extension.ts')],
+    write: true,
+    format: 'cjs',
+    bundle: true,
+    metafile: true,
+    sourcemap: true, // .vscodeignore ignores .map files when bundling!!
+    mainFields: ['module', 'main'], // https://stackoverflow.com/a/69352281
+    minify: true,
+    loader: {
+        '.jpg': 'file',
+        '.gif': 'file',
+        '.mp4': 'file',
+        '.graphql': 'text',
+        '.png': 'file',
+        '.svg': 'file'
+    },
+    platform: 'node',
+    target: 'node12.22',
+    external: [
+        'vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+        // '@sap/guided-answers-extension-webapp'
+    ],
+    plugins: [
+        copy({
+            // workaround because vsce doesn't support pnpm (https://github.com/microsoft/vscode-vsce/issues/421)
+            // so it doesn't copy node_modules to vsix.
+            assets: {
+                from: ['../webapp/dist/guidedAnswers.js', '../webapp/dist/guidedAnswers.css'],
+                to: ['.']
+            }
+        })
+    ]
+};
+
+if (process.argv.slice(2).includes('--watch')) {
+    console.log('Applyin watch config');
+    buildConfig.watch = true;
+    buildConfig.minify = false;
+}
+
 require('esbuild')
-    .build({
-        logLevel: 'info',
-        outfile: 'dist/extension-min.js',
-        entryPoints: [join(process.cwd(), 'src/extension.ts')],
-        write: true,
-        format: 'cjs',
-        bundle: true,
-        metafile: true,
-        sourcemap: true, // .vscodeignore ignores .map files when bundling!!
-        mainFields: ['module', 'main'], // https://stackoverflow.com/a/69352281
-        minify: true,
-        loader: {
-            '.jpg': 'file',
-            '.gif': 'file',
-            '.mp4': 'file',
-            '.graphql': 'text',
-            '.png': 'file',
-            '.svg': 'file'
-        },
-        platform: 'node',
-        target: 'node12.22',
-        external: [
-            'vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
-            // '@sap/guided-answers-extension-webapp'
-        ],
-        plugins: [
-            copy({
-                // workaround because vsce doesn't support pnpm (https://github.com/microsoft/vscode-vsce/issues/421)
-                // so it doesn't copy node_modules to vsix.
-                assets: {
-                    from: ['../webapp/dist/guidedAnswers.js', '../webapp/dist/guidedAnswers.css'],
-                    to: ['.']
-                }
-            })
-        ]
-    })
+    .build(buildConfig)
     .catch((error) => {
-        console.log(error.message);
+        console.log(error);
         process.exit(1);
     });

--- a/packages/ide-extension/package.json
+++ b/packages/ide-extension/package.json
@@ -34,6 +34,7 @@
         "lint": "eslint . --ext .ts",
         "ide-ext:package": "vsce package",
         "test": "jest --ci --forceExit --detectOpenHandles --colors",
+        "watch": "pnpm clean && node esbuild.js --watch",
         "vscode:prepublish": "pnpm run build"
     },
     "activationEvents": [

--- a/packages/ide-extension/src/extension.ts
+++ b/packages/ide-extension/src/extension.ts
@@ -1,7 +1,9 @@
 import type { ExtensionContext } from 'vscode';
+import { window } from 'vscode';
 import { commands } from 'vscode';
 import { logString } from './logger/logger';
 import { GuidedAnswersPanel } from './panel/guidedAnswersPanel';
+import type { StartOptions } from './types';
 
 /**
  *  Activate function is called by VSCode when the extension gets active.
@@ -10,11 +12,14 @@ import { GuidedAnswersPanel } from './panel/guidedAnswersPanel';
  */
 export function activate(context: ExtensionContext): void {
     context.subscriptions.push(
-        commands.registerCommand('sap.ux.guidedAnswer.openGuidedAnswer', (options?: { treeId: number }) => {
-            const treeId = options?.treeId;
-            logString(`Guided Answers command called. (TreeId: ${treeId})`);
-            const guidedAnswersPanel = new GuidedAnswersPanel(treeId);
-            guidedAnswersPanel.show();
+        commands.registerCommand('sap.ux.guidedAnswer.openGuidedAnswer', (options?: StartOptions) => {
+            try {
+                logString(`Guided Answers command called. ${options ? '\nOptions: ' + JSON.stringify(options) : ''}`);
+                const guidedAnswersPanel = new GuidedAnswersPanel(options);
+                guidedAnswersPanel.show();
+            } catch (error) {
+                window.showErrorMessage(`Error while starting Guided Answers: ${(error as Error).message}`);
+            }
         })
     );
 }

--- a/packages/ide-extension/src/extension.ts
+++ b/packages/ide-extension/src/extension.ts
@@ -1,6 +1,5 @@
 import type { ExtensionContext } from 'vscode';
-import { window } from 'vscode';
-import { commands } from 'vscode';
+import { commands, window } from 'vscode';
 import { logString } from './logger/logger';
 import { GuidedAnswersPanel } from './panel/guidedAnswersPanel';
 import type { StartOptions } from './types';

--- a/packages/ide-extension/src/types.ts
+++ b/packages/ide-extension/src/types.ts
@@ -1,0 +1,6 @@
+import type { GuidedAnswerNodeId, GuidedAnswerTreeId } from '@sap/guided-answers-extension-types';
+
+export interface StartOptions {
+    treeId: GuidedAnswerTreeId;
+    nodeIdPath?: GuidedAnswerNodeId[];
+}

--- a/packages/ide-extension/test/__mocks__/vscode.js
+++ b/packages/ide-extension/test/__mocks__/vscode.js
@@ -42,7 +42,8 @@ const window = {
     createTerminal: () => {
         show: jest.fn();
         sendText: jest.fn();
-    }
+    },
+    showErrorMessage: jest.fn()
 };
 
 const workspace = {

--- a/packages/ide-extension/test/extension.test.ts
+++ b/packages/ide-extension/test/extension.test.ts
@@ -5,6 +5,10 @@ import * as logger from '../src/logger/logger';
 import { activate } from '../src/extension';
 
 describe('Extension test', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     test('activate is function', () => {
         expect(typeof activate === 'function').toBeTruthy();
     });
@@ -58,5 +62,40 @@ describe('Extension test', () => {
         ).toMatchSnapshot();
         expect(webViewPanelMock.reveal).toBeCalled();
         expect(loggerMock).toBeCalled();
+    });
+
+    test('execute command with parameters', () => {
+        // Mock setup
+        const loggerMock = jest.spyOn(logger, 'logString').mockImplementation(() => null);
+        const subscriptionsMock = jest.spyOn(commands, 'registerCommand');
+        const context = {
+            subscriptions: []
+        };
+
+        // Test execution
+        activate(context as unknown as ExtensionContext);
+        subscriptionsMock.mock.calls[0][1]({ treeId: 0, nodeIdPath: [1, 2, 3] });
+
+        // Result check
+        expect(loggerMock.mock.calls[0][0]).toContain('{"treeId":0,"nodeIdPath":[1,2,3]}');
+    });
+
+    test('execute command error occurs', () => {
+        // Mock setup
+        const loggerMock = jest.spyOn(logger, 'logString').mockImplementation(() => {
+            throw Error('ERROR');
+        });
+        const showErrorMessageMock = jest.spyOn(window, 'showErrorMessage');
+        const subscriptionsMock = jest.spyOn(commands, 'registerCommand');
+        const context = {
+            subscriptions: []
+        };
+
+        // Test execution
+        activate(context as unknown as ExtensionContext);
+        subscriptionsMock.mock.calls[0][1]();
+
+        // Result check
+        expect(showErrorMessageMock.mock.calls[0][0]).toContain('ERROR');
     });
 });

--- a/packages/ide-extension/test/panel/guidedAnswersPanel.test.ts
+++ b/packages/ide-extension/test/panel/guidedAnswersPanel.test.ts
@@ -1,0 +1,205 @@
+import { window, WebviewPanel, commands } from 'vscode';
+import * as apiMock from '@sap/guided-answers-extension-core';
+import {
+    Command,
+    EXECUTE_COMMAND,
+    GuidedAnswerActions,
+    GuidedAnswerAPI,
+    GuidedAnswerNodeId,
+    GuidedAnswerTree,
+    GuidedAnswerTreeId,
+    SEARCH_TREE,
+    SELECT_NODE,
+    SET_ACTIVE_TREE,
+    UPDATE_ACTIVE_NODE,
+    UPDATE_GUIDED_ANSWER_TREES,
+    UPDATE_LOADING,
+    WEBVIEW_READY
+} from '@sap/guided-answers-extension-types';
+import { GuidedAnswersPanel } from '../../src/panel/guidedAnswersPanel';
+import * as logger from '../../src/logger/logger';
+
+type WebviewMessageCallback = (action: GuidedAnswerActions) => void;
+
+describe('GuidedAnswersPanel', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('Smoketest new GuidedAnswersPanel', () => {
+        // Mock setup
+        const loggerMock = jest.spyOn(logger, 'logString').mockImplementation(() => null);
+
+        // Test execution
+        const gaPanel = new GuidedAnswersPanel();
+
+        // Result check
+        expect(gaPanel).toBeDefined();
+    });
+
+    test('GuidedAnswersPanel communication WEBVIEW_READY', async () => {
+        // Mock setup
+        const loggerMock = jest.spyOn(logger, 'logString').mockImplementation(() => null);
+        let onDidReceiveMessageMock: WebviewMessageCallback = () => {};
+        const webViewPanelMock = getWebViewPanelMock((callback: WebviewMessageCallback) => {
+            onDidReceiveMessageMock = callback;
+        });
+        jest.spyOn(window, 'createWebviewPanel').mockImplementation(() => webViewPanelMock);
+
+        // Test execution
+        new GuidedAnswersPanel();
+        await onDidReceiveMessageMock({ type: WEBVIEW_READY });
+
+        // Result check
+        expect(loggerMock).toBeCalledWith('Webview is ready to receive actions');
+    });
+
+    test('GuidedAnswersPanel communication WEBVIEW_READY with start paramter tree id', async () => {
+        // Mock setup
+        const loggerMock = jest.spyOn(logger, 'logString').mockImplementation(() => null);
+        let onDidReceiveMessageMock: WebviewMessageCallback = () => {};
+        const webViewPanelMock = getWebViewPanelMock((callback: WebviewMessageCallback) => {
+            onDidReceiveMessageMock = callback;
+        });
+        jest.spyOn(window, 'createWebviewPanel').mockImplementation(() => webViewPanelMock);
+        jest.spyOn(apiMock, 'getGuidedAnswerApi').mockImplementation(() => getApiMock(1234));
+
+        // Test execution
+        new GuidedAnswersPanel({ treeId: 1 });
+        await onDidReceiveMessageMock({ type: WEBVIEW_READY });
+
+        // Result check
+        expect(loggerMock).toBeCalledWith('Webview is ready to receive actions');
+        expect((webViewPanelMock.webview.postMessage as jest.Mock).mock.calls).toEqual([
+            [{ type: SET_ACTIVE_TREE, payload: { TREE_ID: 1, FIRST_NODE_ID: 1234 } }],
+            [{ type: UPDATE_ACTIVE_NODE, payload: { NODE_ID: 1234, TITLE: 'Node 1234' } }],
+            [{ type: UPDATE_LOADING, payload: false }]
+        ]);
+    });
+
+    test('GuidedAnswersPanel communication WEBVIEW_READY with start paramters tree id and node path', async () => {
+        // Mock setup
+        const loggerMock = jest.spyOn(logger, 'logString').mockImplementation(() => null);
+        let onDidReceiveMessageMock: WebviewMessageCallback = () => {};
+        const webViewPanelMock = getWebViewPanelMock((callback: WebviewMessageCallback) => {
+            onDidReceiveMessageMock = callback;
+        });
+        jest.spyOn(window, 'createWebviewPanel').mockImplementation(() => webViewPanelMock);
+        jest.spyOn(apiMock, 'getGuidedAnswerApi').mockImplementation(() => getApiMock());
+
+        // Test execution
+        new GuidedAnswersPanel({ treeId: 11, nodeIdPath: [100, 200, 300] });
+        await onDidReceiveMessageMock({ type: WEBVIEW_READY });
+
+        // Result check
+        expect(loggerMock).toBeCalledWith('Webview is ready to receive actions');
+        expect((webViewPanelMock.webview.postMessage as jest.Mock).mock.calls).toEqual([
+            [{ type: SET_ACTIVE_TREE, payload: { TREE_ID: 11 } }],
+            [{ type: UPDATE_ACTIVE_NODE, payload: { NODE_ID: 100 } }],
+            [{ type: UPDATE_ACTIVE_NODE, payload: { NODE_ID: 200 } }],
+            [{ type: UPDATE_ACTIVE_NODE, payload: { NODE_ID: 300 } }],
+            [{ type: UPDATE_LOADING, payload: false }]
+        ]);
+    });
+
+    test('GuidedAnswersPanel communication SELECT_NODE', async () => {
+        // Mock setup
+        const loggerMock = jest.spyOn(logger, 'logString').mockImplementation(() => null);
+        let onDidReceiveMessageMock: WebviewMessageCallback = () => {};
+        const webViewPanelMock = getWebViewPanelMock((callback: WebviewMessageCallback) => {
+            onDidReceiveMessageMock = callback;
+        });
+        jest.spyOn(window, 'createWebviewPanel').mockImplementation(() => webViewPanelMock);
+        jest.spyOn(apiMock, 'getGuidedAnswerApi').mockImplementation(() => getApiMock());
+
+        // Test execution
+        new GuidedAnswersPanel();
+        await onDidReceiveMessageMock({ type: SELECT_NODE, payload: 42 });
+
+        // Result check
+        expect(webViewPanelMock.webview.postMessage).toBeCalledWith({
+            type: UPDATE_ACTIVE_NODE,
+            payload: { NODE_ID: 42, TITLE: 'Node 42' }
+        });
+    });
+
+    test('GuidedAnswersPanel communication EXECUTE_COMMAND', async () => {
+        // Mock setup
+        const loggerMock = jest.spyOn(logger, 'logString').mockImplementation(() => null);
+        let onDidReceiveMessageMock: WebviewMessageCallback = () => {};
+        const webViewPanelMock = getWebViewPanelMock((callback: WebviewMessageCallback) => {
+            onDidReceiveMessageMock = callback;
+        });
+        jest.spyOn(window, 'createWebviewPanel').mockImplementation(() => webViewPanelMock);
+        const commandMock = jest.spyOn(commands, 'executeCommand');
+
+        // Test execution
+        new GuidedAnswersPanel();
+        await onDidReceiveMessageMock({
+            type: EXECUTE_COMMAND,
+            payload: {
+                exec: {
+                    commandId: 'MOCK.COMMAND',
+                    extensionId: 'MOCKEXT',
+                    argument: { arguments: { test: 'MOCKARG' } }
+                }
+            } as unknown as Command
+        });
+
+        // Result check
+        expect(commandMock).toBeCalledWith('MOCK.COMMAND', { arguments: { test: 'MOCKARG' } });
+    });
+
+    test('GuidedAnswersPanel communication SEARCH_TREE', async () => {
+        // Mock setup
+        const loggerMock = jest.spyOn(logger, 'logString').mockImplementation(() => null);
+        let onDidReceiveMessageMock: WebviewMessageCallback = () => {};
+        const webViewPanelMock = getWebViewPanelMock((callback: WebviewMessageCallback) => {
+            onDidReceiveMessageMock = callback;
+        });
+        jest.spyOn(window, 'createWebviewPanel').mockImplementation(() => webViewPanelMock);
+        jest.spyOn(apiMock, 'getGuidedAnswerApi').mockImplementation(() => getApiMock());
+
+        // Test execution
+        new GuidedAnswersPanel();
+        await onDidReceiveMessageMock({ type: SEARCH_TREE, payload: '' });
+
+        // Result check
+        expect(webViewPanelMock.webview.postMessage).toBeCalledWith({
+            type: UPDATE_GUIDED_ANSWER_TREES,
+            payload: [{ TREEE_ID: 1 }, { TREEE_ID: 2 }, { TREEE_ID: 3 }]
+        });
+    });
+});
+
+const getWebViewPanelMock = (onDidReceiveMessage: (callback: WebviewMessageCallback) => void) =>
+    ({
+        webview: {
+            message: '',
+            html: '',
+            onDidReceiveMessage,
+            asWebviewUri: jest.fn().mockReturnValue(''),
+            cspSource: '',
+            postMessage: jest.fn()
+        },
+        onDidChangeViewState: jest.fn(),
+        onDidDispose: jest.fn(),
+        reveal: jest.fn()
+    } as unknown as WebviewPanel);
+
+const getApiMock = (firstNodeId?: number) =>
+    ({
+        getTreeById: (treeId: GuidedAnswerTreeId) => {
+            const tree = {
+                TREE_ID: treeId
+            } as unknown as GuidedAnswerTree;
+            if (firstNodeId) {
+                tree.FIRST_NODE_ID = firstNodeId;
+            }
+            return Promise.resolve(tree);
+        },
+        getNodeById: (nodeId: GuidedAnswerNodeId) => Promise.resolve({ NODE_ID: nodeId, TITLE: `Node ${nodeId}` }),
+        getNodePath: (nodeIdPath: GuidedAnswerNodeId[]) =>
+            Promise.resolve(nodeIdPath.map((nodeId) => ({ NODE_ID: nodeId }))),
+        getTrees: () => Promise.resolve([{ TREEE_ID: 1 }, { TREEE_ID: 2 }, { TREEE_ID: 3 }])
+    } as unknown as GuidedAnswerAPI);

--- a/packages/types/src/actions.ts
+++ b/packages/types/src/actions.ts
@@ -13,8 +13,10 @@ import type {
     SetQueryValue,
     UpdateGuidedAnserTrees,
     UpdateActiveNode,
-    WebviewReady
+    WebviewReady,
+    UpdateLoading
 } from './types';
+import { UPDATE_LOADING } from './types';
 import {
     EXECUTE_COMMAND,
     GO_TO_PREVIOUS_PAGE,
@@ -38,6 +40,11 @@ export const selectNode = (payload: GuidedAnswerNodeId): SelectNode => ({ type: 
 
 export const updateActiveNode = (payload: GuidedAnswerNode): UpdateActiveNode => ({
     type: UPDATE_ACTIVE_NODE,
+    payload
+});
+
+export const updateLoading = (payload: boolean): UpdateLoading => ({
+    type: UPDATE_LOADING,
     payload
 });
 

--- a/packages/types/src/actions.ts
+++ b/packages/types/src/actions.ts
@@ -16,7 +16,6 @@ import type {
     WebviewReady,
     UpdateLoading
 } from './types';
-import { UPDATE_LOADING } from './types';
 import {
     EXECUTE_COMMAND,
     GO_TO_PREVIOUS_PAGE,
@@ -28,6 +27,7 @@ import {
     SET_QUERY_VALUE,
     UPDATE_GUIDED_ANSWER_TREES,
     UPDATE_ACTIVE_NODE,
+    UPDATE_LOADING,
     WEBVIEW_READY
 } from './types';
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -30,6 +30,7 @@ export interface GuidedAnswerAPI {
     getNodeById: (id: GuidedAnswerNodeId) => Promise<GuidedAnswerNode>;
     getTreeById: (id: GuidedAnswerTreeId) => Promise<GuidedAnswerTree>;
     getTrees: (query?: string) => Promise<GuidedAnswerTree[]>;
+    getNodePath: (nodeIdPath: GuidedAnswerNodeId[]) => Promise<GuidedAnswerNode[]>;
 }
 
 export interface VSCodeCommand {
@@ -80,6 +81,7 @@ export type GuidedAnswerActions =
     | UpdateGuidedAnserTrees
     | SelectNode
     | UpdateActiveNode
+    | UpdateLoading
     | GoToPreviousPage
     | GoToAllAnswers
     | RestartAnswer
@@ -105,6 +107,12 @@ export const UPDATE_ACTIVE_NODE = 'UPDATE_ACTIVE_NODE';
 export interface UpdateActiveNode {
     type: typeof UPDATE_ACTIVE_NODE;
     payload: GuidedAnswerNode;
+}
+
+export const UPDATE_LOADING = 'UPDATE_LOADING';
+export interface UpdateLoading {
+    type: typeof UPDATE_LOADING;
+    payload: boolean;
 }
 
 export const GO_TO_PREVIOUS_PAGE = 'GO_TO_PREVIOUS_PAGE';

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -24,7 +24,7 @@
         "@types/react": "17.0.43",
         "@types/react-dom": "17.0.14",
         "@types/react-redux": "7.1.23",
-        "@vscode/webview-ui-toolkit": "0.9.3",
+        "@vscode/webview-ui-toolkit": "1.0.0",
         "autoprefixer": "10.4.4",
         "enzyme": "3.11.0",
         "enzyme-adapter-react-16": "1.15.6",

--- a/packages/webapp/src/webview/state/reducers.ts
+++ b/packages/webapp/src/webview/state/reducers.ts
@@ -2,6 +2,7 @@ import type { GuidedAnswerActions } from '@sap/guided-answers-extension-types';
 import {
     UPDATE_GUIDED_ANSWER_TREES,
     UPDATE_ACTIVE_NODE,
+    UPDATE_LOADING,
     GO_TO_PREVIOUS_PAGE,
     GO_TO_ALL_ANSWERS,
     RESTART_ANSWER,
@@ -18,6 +19,7 @@ import type { AppState } from '../types';
  */
 export function getInitialState(): AppState {
     return {
+        loading: true,
         query: '',
         guidedAnswerTrees: [],
         activeGuidedAnswerNode: [],
@@ -54,6 +56,10 @@ export const reducer: Reducer<AppState, GuidedAnswerActions> = (
             } else {
                 newState.activeGuidedAnswerNode.push(action.payload);
             }
+            break;
+        }
+        case UPDATE_LOADING: {
+            newState.loading = action.payload;
             break;
         }
         case GO_TO_PREVIOUS_PAGE: {

--- a/packages/webapp/src/webview/types.ts
+++ b/packages/webapp/src/webview/types.ts
@@ -1,6 +1,7 @@
 import type { GuidedAnswerNode, GuidedAnswerTree } from '@sap/guided-answers-extension-types';
 
 export interface AppState {
+    loading: boolean;
     query: string;
     guidedAnswerTrees: GuidedAnswerTree[];
     activeGuidedAnswerNode: GuidedAnswerNode[];

--- a/packages/webapp/src/webview/ui/components/App/App.scss
+++ b/packages/webapp/src/webview/ui/components/App/App.scss
@@ -85,3 +85,8 @@ ul.striped-list > li:nth-of-type(odd) {
 .text-underline {
     text-decoration: underline;
 }
+
+#loading-indicator {
+    width: 100%;
+    margin-top: 60px;
+}

--- a/packages/webapp/src/webview/ui/components/App/App.tsx
+++ b/packages/webapp/src/webview/ui/components/App/App.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { VSCodeProgressRing } from '@vscode/webview-ui-toolkit/react';
 import { AppState } from '../../../types';
 import { actions } from '../../../state';
 import { GuidedAnswerNode } from '../GuidedAnswerNode';
@@ -17,7 +18,9 @@ export function App(): ReactElement {
     const appState = useSelector<AppState, AppState>((state) => state);
 
     let content;
-    if (appState.activeGuidedAnswerNode.length > 0) {
+    if (appState.loading) {
+        content = <VSCodeProgressRing id="loading-indicator" />;
+    } else if (appState.activeGuidedAnswerNode.length > 0) {
         content = <GuidedAnswerNode />;
     } else if (appState.guidedAnswerTrees) {
         content =

--- a/packages/webapp/src/webview/ui/components/Header/SearchField/SearchField.tsx
+++ b/packages/webapp/src/webview/ui/components/Header/SearchField/SearchField.tsx
@@ -16,6 +16,7 @@ export function SearchField() {
             <VSCodeTextField
                 className="tree-search-field"
                 value={appState.query}
+                readOnly={appState.loading}
                 placeholder="Search Guided Answers"
                 id="search-field"
                 onInput={(e: any) => {

--- a/packages/webapp/test/App.test.tsx
+++ b/packages/webapp/test/App.test.tsx
@@ -25,7 +25,6 @@ jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
     useSelector: jest
         .fn()
-        .mockReturnValue({ activeGuidedAnswerNode: [{ a: 0 }, { b: 0 }] })
         .mockReturnValueOnce({
             activeGuidedAnswerNode: [],
             guidedAnswerTrees: [],
@@ -46,6 +45,8 @@ jest.mock('react-redux', () => ({
             query: 'fiori tools',
             searchResultCount: 1
         })
+        .mockReturnValueOnce({ activeGuidedAnswerNode: [{ a: 0 }, { b: 0 }] })
+        .mockReturnValueOnce({ loading: true, activeGuidedAnswerNode: [] })
 }));
 
 describe('<NoAnswersFound />', () => {
@@ -89,5 +90,9 @@ describe('<NoAnswersFound />', () => {
         expect(wrapper.find('Header').length).toBe(1);
         expect(wrapper.find('.guided-answer__container').length).toBe(1);
         expect(wrapper.find('GuidedAnswerNode').length).toBe(1);
+    });
+
+    it('Should render loading indicator', () => {
+        expect(wrapper.find('#loading-indicator').length).toBe(1);
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,7 +103,7 @@ importers:
             '@types/react': 17.0.43
             '@types/react-dom': 17.0.14
             '@types/react-redux': 7.1.23
-            '@vscode/webview-ui-toolkit': 0.9.3
+            '@vscode/webview-ui-toolkit': 1.0.0
             autoprefixer: 10.4.4
             enzyme: 3.11.0
             enzyme-adapter-react-16: 1.15.6
@@ -132,7 +132,7 @@ importers:
             '@types/react': 17.0.43
             '@types/react-dom': 17.0.14
             '@types/react-redux': 7.1.23
-            '@vscode/webview-ui-toolkit': 0.9.3_react@16.14.0
+            '@vscode/webview-ui-toolkit': 1.0.0_react@16.14.0
             autoprefixer: 10.4.4_postcss@8.4.12
             enzyme: 3.11.0
             enzyme-adapter-react-16: 1.15.6_j6bpv5pizkyfppcg2tmva6pmii
@@ -2395,10 +2395,10 @@ packages:
             eslint-visitor-keys: 3.3.0
         dev: true
 
-    /@vscode/webview-ui-toolkit/0.9.3_react@16.14.0:
+    /@vscode/webview-ui-toolkit/1.0.0_react@16.14.0:
         resolution:
             {
-                integrity: sha512-uEEpTVA21zkHtWMR8TPT7vbIZ1+tvfhQPThEdmmDjh0PulKPvaAVNqnGbQitU3F9GVqpq2AdIKAq6N1jFeBoXg==
+                integrity: sha512-/qaHYZXqvIKkao54b7bLzyNH8BC+X4rBmTUx1MvcIiCjqRMxml0BCpqJhnDpfrCb0IOxXRO8cAy1eB5ayzQfBA==
             }
         peerDependencies:
             react: '>=16.9.0'


### PR DESCRIPTION
# Issue

https://github.com/SAP/guided-answers-extension/issues/174

## Description
Add functionality to call Guided Answers command with node path parameter, e.g.:

```
commands.executeCommand('sap.ux.guidedAnswer.openGuidedAnswer', { treeId: 3046, nodeIdPath: [45995, 45996, 46000] });
```

![Screen Recording 2022-07-15 at 3 50 42 PM (1)](https://user-images.githubusercontent.com/66327622/179328330-1293c1da-b577-4229-afa7-5c774d868f99.gif)

I've also adjusted `esbuild.js` and `package.json` of `ide-extension` to enable `watch` mode. 


## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [x] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
