### PR TITLE
Feat/ga/filter commands 164

### DIFF
--- a/packages/ide-extension/src/enhancement/enhancements.json
+++ b/packages/ide-extension/src/enhancement/enhancements.json
@@ -9,7 +9,8 @@
                 "exec": {
                     "extensionId": "sapse.sap-ux-application-modeler-extension",
                     "commandId": "sap.ux.environmentcheck.archiveProject"
-                }
+                },
+                "env": ["VSCODE", "BAS"]
             }
         },
         {
@@ -20,7 +21,8 @@
                 "exec": {
                     "extensionId": "sapse.sap-ux-application-modeler-extension",
                     "commandId": "sap.ux.environmentcheck.open"
-                }
+                },
+                "env": ["BAS"]
             }
         }
     ]

--- a/packages/ide-extension/src/enhancement/enhancements.json
+++ b/packages/ide-extension/src/enhancement/enhancements.json
@@ -10,7 +10,7 @@
                     "extensionId": "sapse.sap-ux-application-modeler-extension",
                     "commandId": "sap.ux.environmentcheck.archiveProject"
                 },
-                "env": ["VSCODE", "BAS"]
+                "platforms": ["VSCODE", "BAS"]
             }
         },
         {
@@ -22,7 +22,7 @@
                     "extensionId": "sapse.sap-ux-application-modeler-extension",
                     "commandId": "sap.ux.environmentcheck.open"
                 },
-                "env": ["BAS"]
+                "platforms": ["BAS"]
             }
         }
     ]

--- a/packages/ide-extension/src/enhancement/enhancements.ts
+++ b/packages/ide-extension/src/enhancement/enhancements.ts
@@ -14,7 +14,7 @@ enum ENV {
 }
 
 /**
- * Enumeration of ide types
+ * Enumeration of ide platform types
  */
 enum IDE_PLATFORMS {
     VSCODE = 'VSCODE',
@@ -47,7 +47,7 @@ function classifyEnhancements<T extends HTMLEnhancement | NodeEnhancement>(
         if (isVSCodeCommand(enhancement.command.exec)) {
             if (
                 extensions.getExtension(enhancement.command.exec.extensionId) &&
-                enhancement.command.env.includes(getIde())
+                enhancement.command.platforms.includes(getIde())
             ) {
                 applicable.push(enhancement);
             } else {

--- a/packages/ide-extension/src/enhancement/enhancements.ts
+++ b/packages/ide-extension/src/enhancement/enhancements.ts
@@ -1,9 +1,34 @@
 import { extensions } from 'vscode';
 import { isVSCodeCommand } from '@sap/guided-answers-extension-types';
+import type { IDE } from '@sap/guided-answers-extension-types';
 import type { HTMLEnhancement, NodeEnhancement } from '@sap/guided-answers-extension-types';
 import { logString } from '../logger/logger';
 
 import enhancementsJson from './enhancements.json';
+
+/**
+ * Enumeration of environment variable used in AppStudio
+ */
+enum ENV {
+    H2O_URL = 'H2O_URL'
+}
+
+/**
+ * Enumeration of ide types
+ */
+enum IDE_PLATFORMS {
+    VSCODE = 'VSCODE',
+    BAS = 'BAS'
+}
+
+/**
+ * Return the user development platform
+ *
+ * @returns - IDE type
+ */
+function getIde(): IDE {
+    return process.env[ENV.H2O_URL] ? IDE_PLATFORMS.BAS : IDE_PLATFORMS.VSCODE;
+}
 
 /**
  * Classifies enhancements as applicable and inapplicable. There can be different reasons for a command to be
@@ -20,7 +45,10 @@ function classifyEnhancements<T extends HTMLEnhancement | NodeEnhancement>(
 
     for (const enhancement of enhancements) {
         if (isVSCodeCommand(enhancement.command.exec)) {
-            if (extensions.getExtension(enhancement.command.exec.extensionId)) {
+            if (
+                extensions.getExtension(enhancement.command.exec.extensionId) &&
+                enhancement.command.env.includes(getIde())
+            ) {
                 applicable.push(enhancement);
             } else {
                 inapplicable.push(enhancement);
@@ -41,8 +69,12 @@ export function getEnhancements(): {
     nodeEnhancements: NodeEnhancement[];
     htmlEnhancements: HTMLEnhancement[];
 } {
-    const htmlEnhancements = classifyEnhancements<HTMLEnhancement>(enhancementsJson.htmlEnhancements);
-    const nodeEnhancements = classifyEnhancements<NodeEnhancement>(enhancementsJson.nodeEnhancements);
+    const htmlEnhancements = classifyEnhancements<HTMLEnhancement>(
+        enhancementsJson.htmlEnhancements as HTMLEnhancement[]
+    );
+    const nodeEnhancements = classifyEnhancements<NodeEnhancement>(
+        enhancementsJson.nodeEnhancements as NodeEnhancement[]
+    );
 
     if (htmlEnhancements.applicable.length > 0) {
         logString(`Applicable html enhancements:\n${JSON.stringify(htmlEnhancements.applicable, null, 2)}`);

--- a/packages/ide-extension/src/enhancement/enhancements.ts
+++ b/packages/ide-extension/src/enhancement/enhancements.ts
@@ -7,14 +7,14 @@ import { logString } from '../logger/logger';
 import enhancementsJson from './enhancements.json';
 
 /**
- * Enumeration of environment variable used in AppStudio
+ * Enumeration of environment variable used in AppStudio.
  */
 enum ENV {
     H2O_URL = 'H2O_URL'
 }
 
 /**
- * Enumeration of ide platform types
+ * Enumeration of ide platform types.
  */
 enum IDE_PLATFORMS {
     VSCODE = 'VSCODE',
@@ -22,7 +22,7 @@ enum IDE_PLATFORMS {
 }
 
 /**
- * Return the user development platform
+ * Return the user development platform.
  *
  * @returns - IDE type
  */

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -49,7 +49,7 @@ export interface Command {
     label: string;
     description: string;
     exec: TerminalCommand | VSCodeCommand;
-    env: IDE[];
+    platforms: IDE[];
 }
 
 export interface NodeEnhancement {

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -43,10 +43,13 @@ export interface TerminalCommand {
     arguments: string[];
 }
 
+export type IDE = 'VSCODE' | 'BAS';
+
 export interface Command {
     label: string;
     description: string;
     exec: TerminalCommand | VSCodeCommand;
+    env: IDE[];
 }
 
 export interface NodeEnhancement {


### PR DESCRIPTION
# Issue

https://github.com/SAP/guided-answers-extension/issues/164

## Description

Filter enhancements based on users platform.

Fiori: Open Environment Check appears in BAS but not in Vscode
<img width="1173" alt="Screenshot 2022-07-19 at 12 01 36" src="https://user-images.githubusercontent.com/2386570/179735515-35b1fae2-7afd-49d0-96be-2e055b5853a9.png">
![Screenshot 2022-07-19 at 12 02 15](https://user-images.githubusercontent.com/2386570/179735532-e4e1e0df-df10-4a25-92fb-ccdf63a14645.png)


## Checklist for Pull Requests

- [ ] Supplied as many details as possible on this change
- [ ] Included the link to the associated issue in the Issue section above
- [ ] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [ ] The code has **unit tests** where applicable and is easily unit-testable
- [ ] This branch is appropriately named for the associated issue
