### PR TITLE
fix: change resize handler to useEffect()

### DIFF
--- a/packages/ide-extension/src/panel/guidedAnswersPanel.ts
+++ b/packages/ide-extension/src/panel/guidedAnswersPanel.ts
@@ -168,7 +168,9 @@ export class GuidedAnswersPanel {
                     break;
                 }
                 case SEARCH_TREE: {
+                    logString(`Starting search: ${JSON.stringify(action.payload)}`);
                     const trees = await this.guidedAnswerApi.getTrees(action.payload);
+                    logString(`Found ${trees.resultSize} trees`);
                     this.postActionToWebview(updateGuidedAnswerTrees(trees));
                     break;
                 }

--- a/packages/webapp/src/webview/state/reducers.ts
+++ b/packages/webapp/src/webview/state/reducers.ts
@@ -37,7 +37,7 @@ export function getInitialState(): AppState {
         guideFeedback: null,
         selectedProductFilters: [],
         selectedComponentFilters: [],
-        pageSize: 0
+        pageSize: 20
     };
 }
 


### PR DESCRIPTION
# Issue
memory leak due to `ResizeObserver.observe`

## Description
This PR is a proposal to move the `ResizeObserver` to react hook [onEffect()](https://reactjs.org/docs/hooks-effect.html).

Additionally it adds output log for search and sets the initial page size value to 20 for robustness reasons. 