### PR TITLE
fix(webapp): filter dialog cancel

### DIFF
--- a/.changeset/happy-points-check.md
+++ b/.changeset/happy-points-check.md
@@ -1,0 +1,6 @@
+---
+'@sap/guided-answers-extension-webapp': patch
+'sap-guided-answers-extension': patch
+---
+
+Fix for filter dialog close, caused duplicate results when canceled.

--- a/packages/webapp/src/webview/ui/components/Header/Filters/Filters.tsx
+++ b/packages/webapp/src/webview/ui/components/Header/Filters/Filters.tsx
@@ -67,8 +67,8 @@ export function Filters() {
     const [productFilters, setProductFilters] = useState(appState.guidedAnswerTreeSearchResult.productFilters);
     const [componentFilters, setComponentFilters] = useState(appState.guidedAnswerTreeSearchResult.componentFilters);
     const [query, setQuery] = useState('');
-    const [selectedProductFilters, setSelectedProductFilters] = useState(appState.selectedProductFilters);
-    const [selectedComponentFilters, setSelectedComponentFilters] = useState(appState.selectedProductFilters);
+    const [selectedProductFilters, setSelectedProductFilters] = useState([...appState.selectedProductFilters]);
+    const [selectedComponentFilters, setSelectedComponentFilters] = useState([...appState.selectedProductFilters]);
     const isFilterProducts = filter === PRODUCTS;
     const main = {
         ['.ms-TextField-wrapper > .ms-Label']: {
@@ -113,6 +113,12 @@ export function Filters() {
                 }
             });
         }
+    };
+
+    const cancel = () => {
+        setSelectedComponentFilters([...appState.selectedComponentFilters]);
+        setSelectedProductFilters([...appState.selectedProductFilters]);
+        setDialogVisible(false);
     };
 
     const toggleFilters = (type: string): void => {
@@ -255,7 +261,7 @@ export function Filters() {
                     cancelButtonText={'Cancel'}
                     styles={{ main }}
                     onAccept={() => filterType[filter].apply()}
-                    onCancel={resetFilter}
+                    onCancel={cancel}
                     onDismiss={resetFilter}>
                     <UITextInput placeholder="Search" value={query} onChange={searchFilter} />
                     <FocusZone

--- a/packages/webapp/test/Header/Filters.test.tsx
+++ b/packages/webapp/test/Header/Filters.test.tsx
@@ -134,4 +134,12 @@ describe('<Filters />', () => {
         component = wrapper.find('UIDialog').html();
         expect(component).toMatchInlineSnapshot(`"<span class="ms-layer"></span>"`);
     });
+
+    it('Should close the dialog when cancel button is clicked', () => {
+        expect(wrapper.find('UIDialog').props().isOpen).toBe(false);
+        wrapper.find('#filter-products').simulate('click');
+        expect(wrapper.find('UIDialog').props().isOpen).toBe(true);
+        wrapper.find('UIDialog').simulate('cancel');
+        expect(wrapper.find('UIDialog').props().isOpen).toBe(false);
+    });
 });


### PR DESCRIPTION
# Issue
https://github.com/SAP/guided-answers-extension/issues/300

## Description

When closing the filter dialog with "Cancel", the filer is still applied and results are added leading to multiple result nodes. This PR fixes this, "Cancel" closes the dialog and restores the previous filter values. 

## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [ ] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
