### PR TITLE
Feature- Open GA to side when called via other extensions

### DIFF
--- a/.changeset/sweet-pets-look.md
+++ b/.changeset/sweet-pets-look.md
@@ -1,0 +1,5 @@
+---
+'sap-guided-answers-extension': minor
+---
+
+guided answers opens to the side when another window is open in the editor

--- a/packages/ide-extension/src/panel/guidedAnswersPanel.ts
+++ b/packages/ide-extension/src/panel/guidedAnswersPanel.ts
@@ -55,11 +55,12 @@ export class GuidedAnswersPanel {
          * const webappDirPath = dirname(require.resolve('@sap/guided-answers-extension-webapp'));
          */
         const webappDirPath = __dirname;
+        const extensionView = !this.startOptions ? ViewColumn.Active : ViewColumn.Beside;
         const webAppUri = Uri.file(webappDirPath);
         this.panel = window.createWebviewPanel(
             'sap.ux.guidedAnswer.view',
             'Guided Answers extension by SAP',
-            ViewColumn.Active,
+            extensionView,
             {
                 enableCommandUris: true,
                 enableScripts: true,

--- a/packages/ide-extension/src/panel/guidedAnswersPanel.ts
+++ b/packages/ide-extension/src/panel/guidedAnswersPanel.ts
@@ -55,12 +55,11 @@ export class GuidedAnswersPanel {
          * const webappDirPath = dirname(require.resolve('@sap/guided-answers-extension-webapp'));
          */
         const webappDirPath = __dirname;
-        const extensionView = !this.startOptions ? ViewColumn.Active : ViewColumn.Beside;
         const webAppUri = Uri.file(webappDirPath);
         this.panel = window.createWebviewPanel(
             'sap.ux.guidedAnswer.view',
             'Guided Answers extension by SAP',
-            extensionView,
+            ViewColumn.Beside,
             {
                 enableCommandUris: true,
                 enableScripts: true,


### PR DESCRIPTION
# Feature- Open GA to side when called via other extension

#263

## Description

When another window is opened in the code editor VS code is opened to the side. If there are no windows opened, VS code is opened as full screen

## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [ ] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
