### PR TITLE
fix: re-opening message sent popup

### DIFF
--- a/.changeset/young-ravens-cough.md
+++ b/.changeset/young-ravens-cough.md
@@ -1,0 +1,6 @@
+---
+'@sap/guided-answers-extension-webapp': patch
+'sap-guided-answers-extension': patch
+---
+
+Fix for re-opening 'Message sent' popup dialog

--- a/packages/webapp/esbuild.js
+++ b/packages/webapp/esbuild.js
@@ -19,7 +19,7 @@ require('esbuild')
         metafile: true,
         sourcemap: true, // .vscodeignore ignores .map files when bundling!!
         mainFields: ['module', 'main'], // https://stackoverflow.com/a/69352281
-        minify: true,
+        minify: process.argv.includes('--watch') ? false : true,
         loader: {
             '.jpg': 'file',
             '.gif': 'file',

--- a/packages/webapp/src/webview/ui/components/DialogBoxes/FeedbackSentDialogBox/FeedbackSendDialogBox.tsx
+++ b/packages/webapp/src/webview/ui/components/DialogBoxes/FeedbackSentDialogBox/FeedbackSendDialogBox.tsx
@@ -6,6 +6,7 @@ import { UIIcon } from '@sap-ux/ui-components';
 import { UiIcons } from '../../UIComponentsLib/Icons';
 import { AppState } from '../../../../types';
 import { useSelector } from 'react-redux';
+import { actions } from '../../../../state';
 
 /**
  * The feedback dialog box appears that appears on api response.
@@ -34,6 +35,7 @@ export function FeedbackSendDialogBox(): ReactElement {
     useEffect(() => {
         if (isVisible) {
             const toRef = setTimeout(() => {
+                actions.feedbackResponse(false);
                 setVisible(false);
                 clearTimeout(toRef);
             }, 3000);


### PR DESCRIPTION
# Issue
https://github.com/SAP/guided-answers-extension/issues/385

## Description
Fix for re-opening 'Message sen' popup dialog.

## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [x] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
