### PR TITLE
fix: telemetry and private module consolidation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
     "$schema": "https://unpkg.com/@changesets/config@2.0.0/schema.json",
     "changelog": "@changesets/cli/changelog",
     "commit": false,
-    "fixed": [],
+    "fixed": [["@sap/*", "sap-*"]],
     "linked": [],
     "access": "restricted",
     "baseBranch": "main",

--- a/.changeset/long-chairs-teach.md
+++ b/.changeset/long-chairs-teach.md
@@ -1,0 +1,8 @@
+---
+'sap-guided-answers-extension': minor
+'@sap/guided-answers-extension-webapp': minor
+'@sap/guided-answers-extension-types': minor
+'@sap/guided-answers-extension-core': minor
+---
+
+Telemetry fixes, private module consolidation

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sap/guided-answers-extension-core",
     "description": "Guided Answers extension core module",
-    "version": "1.5.0",
+    "version": "1.12.3",
     "license": "Apache-2.0",
     "private": true,
     "main": "dist/index.js",

--- a/packages/ide-extension/src/telemetry/action-map.ts
+++ b/packages/ide-extension/src/telemetry/action-map.ts
@@ -46,8 +46,8 @@ function getTreeNodeInfo(state: AppState): {
     return {
         treeId: state.activeGuidedAnswer?.TREE_ID.toString() || '',
         treeTitle: state.activeGuidedAnswer?.TITLE || '',
-        lastNodeId: state.activeGuidedAnswerNode.slice(-1)[0].NODE_ID.toString(),
-        lastNodeTitle: state.activeGuidedAnswerNode.slice(-1)[0].TITLE,
+        lastNodeId: state.activeGuidedAnswerNode.slice(-1)[0]?.NODE_ID.toString(),
+        lastNodeTitle: state.activeGuidedAnswerNode.slice(-1)[0]?.TITLE,
         nodeIdPath: state.activeGuidedAnswerNode.map((node) => node.NODE_ID.toString()).join(':'),
         nodeLevel: state.activeGuidedAnswerNode.length.toString()
     };

--- a/packages/ide-extension/src/telemetry/telemetry.ts
+++ b/packages/ide-extension/src/telemetry/telemetry.ts
@@ -57,7 +57,7 @@ export async function trackEvent(event: TelemetryEvent): Promise<void> {
         reporter.sendTelemetryEvent(event.name, properties);
         logString(`Telemetry event '${event.name}': ${JSON.stringify(properties)}`);
     } catch (error) {
-        logString(`Error sending telemetry event ${(error as Error).message}`);
+        logString(`Error sending telemetry event '${event.name}': ${(error as Error).message}`);
     }
 }
 
@@ -68,8 +68,12 @@ export async function trackEvent(event: TelemetryEvent): Promise<void> {
  */
 export async function trackAction(action: SendTelemetry): Promise<void> {
     if (actionMap[action.payload.action.type]) {
-        const properties = actionMap[action.payload.action.type](action);
-        trackEvent({ name: 'USER_INTERACTION', properties });
+        try {
+            const properties = actionMap[action.payload.action.type](action);
+            trackEvent({ name: 'USER_INTERACTION', properties });
+        } catch (error) {
+            logString(`Error sending telemetry action '${action.payload.action.type}': ${(error as Error).message}`);
+        }
     }
 }
 

--- a/packages/ide-extension/src/telemetry/telemetry.ts
+++ b/packages/ide-extension/src/telemetry/telemetry.ts
@@ -20,7 +20,7 @@ let commonProperties: TelemetryCommonProperties | undefined;
  */
 export function initTelemetry(): TelemetryReporter {
     if (!reporter) {
-        reporter = new TelemetryReporter('ga', packageJson.version, key);
+        reporter = new TelemetryReporter(packageJson.name, packageJson.version, key);
     }
     return reporter;
 }

--- a/packages/ide-extension/test/telemetry/actions-map.test.ts
+++ b/packages/ide-extension/test/telemetry/actions-map.test.ts
@@ -1,0 +1,28 @@
+import { SendTelemetry, SEND_TELEMETRY, SET_ACTIVE_TREE } from '@sap/guided-answers-extension-types';
+import type { AppState } from '@sap/guided-answers-extension-types';
+import { actionMap } from '../../src/telemetry/action-map';
+
+describe('Test action mapping', () => {
+    test('Test SET_ACTIVE_TREE map with initial state', () => {
+        // Mock setup
+        const state = { activeGuidedAnswerNode: [] } as unknown as AppState;
+        const telAction = {
+            type: SEND_TELEMETRY,
+            payload: {
+                state,
+                action: {
+                    type: SET_ACTIVE_TREE,
+                    payload: {
+                        TREE_ID: 1234
+                    }
+                }
+            }
+        } as unknown as SendTelemetry;
+
+        // Test execution
+        const result = actionMap[SET_ACTIVE_TREE](telAction);
+
+        // Result check
+        expect(result).toEqual({ action: 'OPEN_TREE', treeId: '1234', treeTitle: '' });
+    });
+});

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sap/guided-answers-extension-types",
     "description": "Guided Answers extension types",
-    "version": "1.4.0",
+    "version": "1.12.3",
     "license": "Apache-2.0",
     "private": true,
     "main": "dist/index.js",

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sap/guided-answers-extension-webapp",
     "description": "Guided Answers extension webview module",
-    "version": "1.10.3",
+    "version": "1.12.3",
     "author": "SAP SE",
     "main": "dist/index.js",
     "private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ overrides:
   strip-ansi@3.0.1>ansi-regex: ^5.0.1
   generic-names@4.0.0>loader-utils: ^3.2.1
 
+patchedDependencies:
+  '@vscode/extension-telemetry@0.6.2':
+    hash: pup67pqt4f46737bpso4uq2qsu
+    path: patches/@vscode__extension-telemetry@0.6.2.patch
+
 importers:
 
   .:
@@ -3128,8 +3133,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -8515,8 +8520,3 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-patchedDependencies:
-  '@vscode/extension-telemetry@0.6.2':
-    hash: pup67pqt4f46737bpso4uq2qsu
-    path: patches/@vscode__extension-telemetry@0.6.2.patch


### PR DESCRIPTION
# Issue
https://github.com/SAP/guided-answers-extension/issues/122

## Description
- Fix for telemetry `SET_ACTIVE_TREE` with unit test
- Improved telemetry error logging
- enable patch for `@vscode/extension-telemetry@0.6.2`
- Use extension module name as prefix for telemetry events
- Consolidate internal module versioning
- Create fixed changeset packages

## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [x] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
