### PR TITLE
chore: pipeline updates and improvements

### DIFF
--- a/.changeset/silent-spies-call.md
+++ b/.changeset/silent-spies-call.md
@@ -1,0 +1,8 @@
+---
+'@sap/guided-answers-extension-core': patch
+'sap-guided-answers-extension': patch
+'@sap/guided-answers-extension-types': patch
+'@sap/guided-answers-extension-webapp': patch
+---
+
+New pipeline settings that among others, produce shorter release description, meaning only what changed is in the description, not the whole changelog

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3.2.0
+              uses: actions/checkout@v3.3.0
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,18 +11,18 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                node-version: [14.x, 16.x, 18.x]
+                node-version: [16.x, 18.x]
         runs-on: ${{ matrix.os }}
         timeout-minutes: 15
         steps:
             - name: Checkout code repository
-              uses: actions/checkout@v3.2.0
+              uses: actions/checkout@v3.3.0
               with:
                   fetch-depth: 0
             - name: Setup pnpm
               uses: pnpm/action-setup@v2.2.2
               with:
-                  version: 7.1.0
+                  version: 7.28.0
                   run_install: true
             - name: Cache pnpm modules
               uses: actions/cache@v3
@@ -46,7 +46,7 @@ jobs:
             - name: Run unit tests
               run: pnpm run test
             - name: Run SonarCloud scan
-              if: matrix.os == 'ubuntu-latest' && matrix.node-version == '14.x'
+              if: matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x'
               uses: sonarsource/sonarcloud-github-action@master
               env:
                   GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
@@ -61,14 +61,14 @@ jobs:
             changes: ${{ steps.changesetVersion.outputs.changes }} # map step output to job output
         steps:
             - name: Checkout code repository
-              uses: actions/checkout@v3.2.0
+              uses: actions/checkout@v3.3.0
               with:
                   fetch-depth: 0
                   token: ${{ secrets.ACCESS_PAT }}
             - name: Setup pnpm
               uses: pnpm/action-setup@v2.2.2
               with:
-                  version: 7.1.0
+                  version: 7.28.0
                   run_install: true
             - name: Cache pnpm modules
               uses: actions/cache@v3
@@ -79,16 +79,16 @@ jobs:
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
                   restore-keys: |
                       ${{ runner.os }}-build-${{ env.cache-name }}-
-            - name: Use Node.js 14.x
+            - name: Use Node.js 16.x
               uses: actions/setup-node@v3
               with:
-                  node-version: 14.x
+                  node-version: 16.x
             - name: Install pnpm modules
               run: pnpm install
             - name: Apply changesets
               id: changesetVersion
               run: |
-                  echo ::set-output name=changes::$(pnpm ci:version 2>&1 | grep -q 'No unreleased changesets found' && echo 'false' || echo 'true')
+                  echo "changes=$(pnpm ci:version 2>&1 | grep -q 'No unreleased changesets found' && echo 'false' || echo 'true')" >> $GITHUB_OUTPUT
                   git status
             - name: Commit and push changes
               if: steps.changesetVersion.outputs.changes == 'true'
@@ -109,11 +109,11 @@ jobs:
         needs: version
         steps:
             - name: Checkout code repository
-              uses: actions/checkout@v3.2.0
+              uses: actions/checkout@v3.3.0
             - name: Setup pnpm
               uses: pnpm/action-setup@v2.2.2
               with:
-                  version: 7.1.0
+                  version: 7.28.0
                   run_install: true
             - name: Cache pnpm modules
               uses: actions/cache@v3
@@ -124,10 +124,10 @@ jobs:
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
                   restore-keys: |
                       ${{ runner.os }}-build-${{ env.cache-name }}-
-            - name: Use Node.js 14.x
+            - name: Use Node.js 16.x
               uses: actions/setup-node@v3
               with:
-                  node-version: 14.x
+                  node-version: 16.x
             - name: Install pnpm modules
               run: pnpm install
             - name: Replace placeholder with instrumentation key
@@ -146,10 +146,15 @@ jobs:
               uses: martinbeentjes/npm-get-version-action@main
               with:
                   path: packages/ide-extension
+            - name: Read last entry of changelog
+              run: |
+                  echo "lastChangelogEntry<<END_CHANGEL0G_ENTRY" >> $GITHUB_ENV
+                  node -e 'require(`changelog-parser`)(`./packages/ide-extension/CHANGELOG.md`).then((c)=>console.log(c?.versions?.[0]?.body || `See CHANGELOG.md for details`))' >> $GITHUB_ENV
+                  echo "END_CHANGEL0G_ENTRY" >> $GITHUB_ENV
             - name: Create Github Release
               uses: softprops/action-gh-release@v1
               with:
-                  body_path: ${{ github.workspace }}/packages/ide-extension/CHANGELOG.md
+                  body: ${{ env.lastChangelogEntry }}
                   draft: false
                   files: packages/ide-extension/sap-guided-answers*.vsix
                   fail_on_unmatched_files: true

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -10,6 +10,6 @@ jobs:
     reuse-lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3.2.0
+            - uses: actions/checkout@v3.3.0
             - name: REUSE Compliance Check
               uses: fsfe/reuse-action@v1

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "@types/node": "14.18.32",
         "@typescript-eslint/eslint-plugin": "5.47.0",
         "@typescript-eslint/parser": "5.47.0",
+        "changelog-parser": "3.0.1",
         "eslint": "8.30.0",
         "eslint-config-prettier": "8.5.0",
         "eslint-import-resolver-typescript": "3.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ overrides:
   strip-ansi@3.0.1>ansi-regex: ^5.0.1
   generic-names@4.0.0>loader-utils: ^3.2.1
 
+patchedDependencies:
+  '@vscode/extension-telemetry@0.6.2':
+    hash: pup67pqt4f46737bpso4uq2qsu
+    path: patches/@vscode__extension-telemetry@0.6.2.patch
+
 importers:
 
   .:
@@ -15,6 +20,7 @@ importers:
       '@types/node': 14.18.32
       '@typescript-eslint/eslint-plugin': 5.47.0
       '@typescript-eslint/parser': 5.47.0
+      changelog-parser: 3.0.1
       eslint: 8.30.0
       eslint-config-prettier: 8.5.0
       eslint-import-resolver-typescript: 3.5.2
@@ -41,6 +47,7 @@ importers:
       '@types/node': 14.18.32
       '@typescript-eslint/eslint-plugin': 5.47.0_5u3jvyfb72rymd44dmiw2z5cbe
       '@typescript-eslint/parser': 5.47.0_d6qaxtm4z57fslwcbi4d5wrunu
+      changelog-parser: 3.0.1
       eslint: 8.30.0
       eslint-config-prettier: 8.5.0_eslint@8.30.0
       eslint-import-resolver-typescript: 3.5.2_2lbwmhbr7bncddqbzzpg77o75m
@@ -2232,13 +2239,11 @@ packages:
 
   /@types/prop-types/15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
-    dev: true
 
   /@types/react-dom/17.0.18:
     resolution: {integrity: sha512-rLVtIfbwyur2iFKykP2w0pl/1unw26b5td16d5xMgp7/yjTHomkyxPYChFoCr/FtEX1lN9wY6lFj1qvKdS5kDw==}
     dependencies:
       '@types/react': 17.0.52
-    dev: true
 
   /@types/react-redux/7.1.24:
     resolution: {integrity: sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==}
@@ -2255,7 +2260,6 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.1
-    dev: true
 
   /@types/redux-mock-store/1.0.3:
     resolution: {integrity: sha512-Wqe3tJa6x9MxMN4DJnMfZoBRBRak1XTPklqj4qkVm5VBpZnC8PSADf4kLuFQ9NAdHaowfWoEeUMz7NWc2GMtnA==}
@@ -2265,7 +2269,6 @@ packages:
 
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
-    dev: true
 
   /@types/semver/6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
@@ -2956,6 +2959,15 @@ packages:
       supports-color: 7.2.0
     dev: true
 
+  /changelog-parser/3.0.1:
+    resolution: {integrity: sha512-1AEVJgnFEO4v5ukfEH/j9cr2Z39Y/GCieNi605azhufAolXF4vQAwZBY8BrUVRkvlI3gwe3i621/PIAW0zmmEQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      line-reader: 0.2.4
+      remove-markdown: 0.5.0
+    dev: true
+
   /char-regex/1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
@@ -3128,8 +3140,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -6161,6 +6173,10 @@ packages:
       lightningcss-win32-x64-msvc: 1.18.0
     dev: true
 
+  /line-reader/0.2.4:
+    resolution: {integrity: sha512-342xzyZZS9uTiKwHJcMacopVl/WjrMMCZS1Qg4Uhl/WBknWRrGFdKOIS1Kec6SaiTcZMtmuxWvvIbPXj/+FMjA==}
+    dev: true
+
   /lines-and-columns/1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
@@ -7093,7 +7109,6 @@ packages:
       prop-types: 15.8.1
       react: 16.14.0
       scheduler: 0.19.1
-    dev: true
 
   /react-i18next/11.18.6_kxtqwj7y4bqaveai3upbyxzsj4:
     resolution: {integrity: sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==}
@@ -7206,7 +7221,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.8.1
-    dev: true
 
   /read-pkg-up/7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -7303,6 +7317,10 @@ packages:
   /regexpp/3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
+    dev: true
+
+  /remove-markdown/0.5.0:
+    resolution: {integrity: sha512-x917M80K97K5IN1L8lUvFehsfhR8cYjGQ/yAMRI9E7JIKivtl5Emo5iD13DhMr+VojzMCiYk8V2byNPwT/oapg==}
     dev: true
 
   /require-directory/2.1.1:
@@ -7452,7 +7470,6 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    dev: true
 
   /semver/5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
@@ -8515,8 +8532,3 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-patchedDependencies:
-  '@vscode/extension-telemetry@0.6.2':
-    hash: pup67pqt4f46737bpso4uq2qsu
-    path: patches/@vscode__extension-telemetry@0.6.2.patch


### PR DESCRIPTION
# Issue
GitHub actions outdated

## Description
- upgrade to `actions/checkout@v3.3.0`
- remove node 14.x builds, set 16.x as default
- use `pnpm@7.28.0` as pnpm patches have not been applied with version `7.1.0`
- switch from `set-output` to `>> $GITHUB_OUTPUT` ([github-actions-deprecating-save-state-and-set-output-commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))
- add current changes to release description only (leveraging `changelog-parser`)

Although not required, the branch of this PR has a changeset to test the full E2E cycle when merging this PR.


## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [x] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
