### PR TITLE
fix(434): fix keyboard navigation for filters

### DIFF
--- a/.changeset/ten-ghosts-reply.md
+++ b/.changeset/ten-ghosts-reply.md
@@ -1,0 +1,5 @@
+---
+"@sap/guided-answers-extension-webapp": patch
+---
+
+fix(434): fix keyboard navigation for filters

--- a/packages/webapp/src/webview/ui/components/App/App.tsx
+++ b/packages/webapp/src/webview/ui/components/App/App.tsx
@@ -74,7 +74,6 @@ export function App(): ReactElement {
                 <NoAnswersFound />
             ) : (
                 <FocusZone direction={FocusZoneDirection.bidirectional} isCircularNavigation={true}>
-                    <FiltersRibbon />
                     <ul className="striped-list" role="listbox">
                         <InfiniteScroll
                             dataLength={appState.guidedAnswerTreeSearchResult.trees.length} //This is important field to render the next data
@@ -137,6 +136,7 @@ export function App(): ReactElement {
                 showNavButons={appState.activeGuidedAnswerNode.length !== 0}
                 showSearch={appState.activeGuidedAnswerNode.length === 0}
             />
+            <FiltersRibbon />
             <main className="guided-answer__container" id="results-container">
                 {content}
             </main>


### PR DESCRIPTION
# Issue

#434

## Description

Fixed bug where user was not able to navigate into the result list, when a filter is used
