### PR TITLE
fix: no interruption for search input

### DIFF
--- a/.changeset/afraid-tigers-cheat.md
+++ b/.changeset/afraid-tigers-cheat.md
@@ -1,0 +1,5 @@
+---
+'sap-guided-answers-extension': patch
+---
+
+Fix for blocking search input

--- a/packages/ide-extension/src/panel/guidedAnswersPanel.ts
+++ b/packages/ide-extension/src/panel/guidedAnswersPanel.ts
@@ -38,6 +38,7 @@ export class GuidedAnswersPanel {
     public readonly panel: WebviewPanel;
     private guidedAnswerApi: GuidedAnswerAPI;
     private startOptions: StartOptions | undefined;
+    private loadingTimeout: NodeJS.Timeout | undefined;
     private readonly ide: IDE;
 
     /**
@@ -197,9 +198,17 @@ export class GuidedAnswersPanel {
     private async getTrees(queryOptions: GuidedAnswersQueryOptions): Promise<GuidedAnswerTreeSearchResult> {
         const showLoadingAnimation = queryOptions.paging?.offset === 0;
         if (showLoadingAnimation) {
-            this.postActionToWebview(updateLoading(true));
+            if (this.loadingTimeout) {
+                clearTimeout(this.loadingTimeout);
+            }
+            this.loadingTimeout = setTimeout(() => {
+                this.postActionToWebview(updateLoading(true));
+            }, 2000);
         }
         const trees = await this.guidedAnswerApi.getTrees(queryOptions);
+        if (this.loadingTimeout) {
+            clearTimeout(this.loadingTimeout);
+        }
         if (showLoadingAnimation) {
             this.postActionToWebview(updateLoading(false));
         }

--- a/packages/webapp/src/webview/ui/components/Header/SearchField/SearchField.tsx
+++ b/packages/webapp/src/webview/ui/components/Header/SearchField/SearchField.tsx
@@ -42,7 +42,7 @@ export function SearchField() {
                                     offset: 0
                                 }
                             });
-                        }, 400);
+                        }, 100);
                     }
                 }}></UISearchBox>
             <Filters />


### PR DESCRIPTION
# Issue
https://github.com/SAP/guided-answers-extension/issues/436

## Description
No interruption for input when starting search. However, if the search takes longer than 2000ms we still show a loading animation and the input is blocked. 


## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [x] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
