### PR TITLE
fix(442): fix filters showing app in wrong app states

### DIFF
--- a/.changeset/tiny-walls-suffer.md
+++ b/.changeset/tiny-walls-suffer.md
@@ -1,0 +1,5 @@
+---
+"@sap/guided-answers-extension-webapp": patch
+---
+
+fix(442): fix filters showing app in wrong app states

--- a/packages/webapp/src/webview/ui/components/App/App.tsx
+++ b/packages/webapp/src/webview/ui/components/App/App.tsx
@@ -136,7 +136,11 @@ export function App(): ReactElement {
                 showNavButons={appState.activeGuidedAnswerNode.length !== 0}
                 showSearch={appState.activeGuidedAnswerNode.length === 0}
             />
-            <FiltersRibbon />
+
+            {appState.guidedAnswerTreeSearchResult.resultSize > 0 && appState.activeGuidedAnswerNode.length === 0 ? (
+                <FiltersRibbon />
+            ) : null}
+
             <main className="guided-answer__container" id="results-container">
                 {content}
             </main>


### PR DESCRIPTION
# Issue

#442 

## Description

Fixed filters showing up in wrong app states like when a node path is open
