### PR TITLE
fix: clear query when URL was detected

### DIFF
--- a/.changeset/loud-cameras-doubt.md
+++ b/.changeset/loud-cameras-doubt.md
@@ -1,0 +1,5 @@
+---
+'sap-guided-answers-extension': minor
+---
+
+Clear query if URL was inserted that cause navigation

--- a/packages/ide-extension/src/panel/guidedAnswersPanel.ts
+++ b/packages/ide-extension/src/panel/guidedAnswersPanel.ts
@@ -1,12 +1,11 @@
 import type { WebviewPanel } from 'vscode';
 import { Uri, ViewColumn, window, workspace } from 'vscode';
-import {
+import type {
     GuidedAnswerActions,
     GuidedAnswerAPI,
     GuidedAnswersQueryOptions,
     GuidedAnswerTreeSearchResult,
-    IDE,
-    setQueryValue
+    IDE
 } from '@sap/guided-answers-extension-types';
 import {
     SELECT_NODE,
@@ -21,6 +20,7 @@ import {
     SEARCH_TREE,
     WEBVIEW_READY,
     setActiveTree,
+    setQueryValue,
     getBetaFeatures,
     feedbackResponse
 } from '@sap/guided-answers-extension-types';

--- a/packages/ide-extension/src/panel/guidedAnswersPanel.ts
+++ b/packages/ide-extension/src/panel/guidedAnswersPanel.ts
@@ -1,11 +1,12 @@
 import type { WebviewPanel } from 'vscode';
 import { Uri, ViewColumn, window, workspace } from 'vscode';
-import type {
+import {
     GuidedAnswerActions,
     GuidedAnswerAPI,
     GuidedAnswersQueryOptions,
     GuidedAnswerTreeSearchResult,
-    IDE
+    IDE,
+    setQueryValue
 } from '@sap/guided-answers-extension-types';
 import {
     SELECT_NODE,
@@ -164,7 +165,7 @@ export class GuidedAnswersPanel {
         } catch (error: any) {
             logString(
                 `Error while processing start options, error was: '${error?.message}'. Start options: \n${
-                    typeof this.startOptions === 'object' ? JSON.stringify(this.startOptions) : this.startOptions
+                    typeof startOptions === 'object' ? JSON.stringify(startOptions) : startOptions
                 }`
             );
             return false;
@@ -256,6 +257,7 @@ export class GuidedAnswersPanel {
                             const startOptionsApplied = await this.processStartOptions(start);
                             this.postActionToWebview(updateLoading(false));
                             if (startOptionsApplied) {
+                                this.postActionToWebview(setQueryValue(''));
                                 return;
                             }
                         }

--- a/packages/ide-extension/test/panel/guidedAnswersPanel.test.ts
+++ b/packages/ide-extension/test/panel/guidedAnswersPanel.test.ts
@@ -12,7 +12,8 @@ import {
     WEBVIEW_READY,
     BETA_FEATURES,
     SEND_FEEDBACK_OUTCOME,
-    SEND_FEEDBACK_COMMENT
+    SEND_FEEDBACK_COMMENT,
+    SET_QUERY_VALUE
 } from '@sap/guided-answers-extension-types';
 import type {
     Command,
@@ -347,7 +348,7 @@ describe('GuidedAnswersPanel', () => {
         await onDidReceiveMessageMock({ type: SEARCH_TREE, payload: { query: '#/tree/12/actions/34:56' } });
 
         // Result check
-        expect(webViewPanelMock.webview.postMessage).toBeCalledTimes(5);
+        expect(webViewPanelMock.webview.postMessage).toBeCalledTimes(6);
         expect(webViewPanelMock.webview.postMessage).toHaveBeenNthCalledWith(1, {
             type: UPDATE_LOADING,
             payload: true
@@ -367,6 +368,10 @@ describe('GuidedAnswersPanel', () => {
         expect(webViewPanelMock.webview.postMessage).toHaveBeenNthCalledWith(5, {
             type: UPDATE_LOADING,
             payload: false
+        });
+        expect(webViewPanelMock.webview.postMessage).toHaveBeenNthCalledWith(6, {
+            type: SET_QUERY_VALUE,
+            payload: ''
         });
     });
 


### PR DESCRIPTION
# Issue
https://github.com/SAP/guided-answers-extension/issues/443

## Description
Change behavior after query was execute with URL: if the URL causes a successful navigation to a tree and node path, we clear the URL from the query field.

## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [x] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
