### PR TITLE
fix: use pnpm@8.6.0

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v2.2.2
               with:
-                  version: 8.5.1
+                  version: 8.6.0
                   run_install: true
             - name: Cache pnpm modules
               uses: actions/cache@v3
@@ -68,7 +68,7 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v2.2.2
               with:
-                  version: 8.5.1
+                  version: 8.6.0
                   run_install: true
             - name: Cache pnpm modules
               uses: actions/cache@v3
@@ -113,7 +113,7 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v2.2.2
               with:
-                  version: 8.5.1
+                  version: 8.6.0
                   run_install: true
             - name: Cache pnpm modules
               uses: actions/cache@v3

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "pnpm": "8",
         "node": ">=16.1.0"
     },
-    "packageManager": "pnpm@8.5.1",
+    "packageManager": "pnpm@8.6.0",
     "pnpm": {
         "overrides": {
             "strip-ansi@3.0.1>ansi-regex": "^5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 overrides:
   strip-ansi@3.0.1>ansi-regex: ^5.0.1


### PR DESCRIPTION
# Issue
pnpm version outdated

## Description
There is a new version `pnpm@8.6.0` that we missed in our last update by a couple of days. This PR updates `pnpm `again. 

## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/knowledge-hub-extension/blob/main/docs/developer-guide.md).
- [x] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
