### PR TITLE
fix(504): remove box sizing specifier for all elements

### DIFF
--- a/.changeset/polite-otters-camp.md
+++ b/.changeset/polite-otters-camp.md
@@ -1,0 +1,5 @@
+---
+"@sap/guided-answers-extension-webapp": patch
+---
+
+fix(504): remove box sizing specifier for all elements

--- a/packages/webapp/src/webview/ui/components/GuidedAnswerNavPath/GuidedAnswerNavPath.scss
+++ b/packages/webapp/src/webview/ui/components/GuidedAnswerNavPath/GuidedAnswerNavPath.scss
@@ -1,8 +1,3 @@
-* {
-    box-sizing: border-box;
-    outline: none;
-}
-
 h1 span {
     font-weight: 600;
 }


### PR DESCRIPTION
# Issue

#504

## Description

* Removed `box-sizing: border-box` that was set for all elements and created inconsistencies between this project and `open-ux-tools`
