### PR TITLE
feat: improve logging and tracing

### DIFF
--- a/packages/ide-extension/src/logger/logger.ts
+++ b/packages/ide-extension/src/logger/logger.ts
@@ -14,3 +14,12 @@ export function logString(message: string): void {
     }
     channel.appendLine(message);
 }
+
+/**
+ * Add a message to trace.
+ *
+ * @param message - trace message
+ */
+export function traceString(message: string): void {
+    console.log(message);
+}

--- a/packages/ide-extension/src/telemetry/telemetry.ts
+++ b/packages/ide-extension/src/telemetry/telemetry.ts
@@ -5,7 +5,7 @@ import { TelemetryClient } from 'applicationinsights';
 import type { Contracts } from 'applicationinsights';
 import type { IDE, SendTelemetry } from '@sap/guided-answers-extension-types';
 import { v4 as uuidv4 } from 'uuid';
-import { logString } from '../logger/logger';
+import { logString, traceString } from '../logger/logger';
 import packageJson from '../../package.json';
 import type { TelemetryEvent, TelemetryReporter } from '../types';
 import { actionMap } from './action-map';
@@ -101,7 +101,7 @@ export async function trackEvent(event: TelemetryEvent): Promise<void> {
         const name = `${packageJson.name}/${event.name}`;
         const properties = propertyValuesToString({ ...event.properties, ...(reporter.commonProperties ?? {}) });
         reporter.client.trackEvent({ name, properties });
-        logString(`Telemetry event '${event.name}': ${JSON.stringify(properties)}`);
+        traceString(`Telemetry event '${event.name}': ${JSON.stringify(properties)}`);
     } catch (error) {
         logString(`Error sending telemetry event '${event.name}': ${(error as Error).message}`);
     }

--- a/packages/ide-extension/test/logger/logger.test.ts
+++ b/packages/ide-extension/test/logger/logger.test.ts
@@ -1,5 +1,5 @@
 import { OutputChannel, window } from 'vscode';
-import { logString } from '../../src/logger/logger';
+import { logString, traceString } from '../../src/logger/logger';
 
 describe('Tests for logging', () => {
     test('Test for logString()', () => {
@@ -14,5 +14,18 @@ describe('Tests for logging', () => {
 
         // Result check
         expect(channelMock.appendLine).toBeCalledWith('LOG_MESSAGE');
+    });
+
+    test('Test for traceString()', () => {
+        // Mock setup
+        const originalLogFn = console.log;
+        console.log = jest.fn();
+
+        // Test execution
+        traceString('TRACE_MESSAGE');
+
+        // Result check
+        expect(console.log).toBeCalledWith('TRACE_MESSAGE');
+        console.log = originalLogFn;
     });
 });

--- a/packages/ide-extension/test/telemetry/telemetry.test.ts
+++ b/packages/ide-extension/test/telemetry/telemetry.test.ts
@@ -62,6 +62,7 @@ describe('Telemetry trackEvent() tests', () => {
         jest.clearAllMocks();
         jest.spyOn(commands, 'registerCommand');
         jest.spyOn(logger, 'logString').mockImplementation(() => null);
+        jest.spyOn(logger, 'traceString').mockImplementation(() => null);
         jest.spyOn(workspace, 'getConfiguration').mockReturnValue({ get: () => true } as any);
 
         const context = {
@@ -145,6 +146,7 @@ describe('Telemetry trackAction() tests', () => {
                 treeTitle: 'Title'
             }
         });
+        expect(logger.traceString).toBeCalledWith(expect.stringContaining('OPEN_TREE'));
     });
 
     test('send UPDATE_ACTIVE_NODE action', () => {


### PR DESCRIPTION
# Issue
Too much noise in OUTPUT tab.

## Description
There are many messages in OUTPUT tab of Guided Answers extension. This PR introduces trace messages, that are for now added to console.log and can be seen in developer tools. 

Better way would be to use [Log output channel](https://code.visualstudio.com/updates/v1_73#_log-output-channel), but this would required to update the min supported VSCode version from `1.39.0` to `1.73` (October 2022).

Code is done in a way that makes it easy to switch to new `LogOutputChannel` afterwards.

## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [x] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
