### PR TITLE
chore: update min vscode version

### DIFF
--- a/packages/ide-extension/package.json
+++ b/packages/ide-extension/package.json
@@ -22,7 +22,7 @@
         "url": "https://github.com/SAP/guided-answers-extension.git"
     },
     "engines": {
-        "vscode": "^1.39.0"
+        "vscode": "^1.73.1"
     },
     "main": "./dist/extension-min.js",
     "private": false,
@@ -83,7 +83,7 @@
         "@sap/guided-answers-extension-core": "workspace:*",
         "@sap/guided-answers-extension-types": "workspace:*",
         "@types/uuid": "9.0.2",
-        "@types/vscode": "1.39.0",
+        "@types/vscode": "1.73.1",
         "@vscode/vsce": "2.19.0",
         "applicationinsights": "2.5.0",
         "esbuild": "0.18.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         specifier: 9.0.2
         version: 9.0.2
       '@types/vscode':
-        specifier: 1.39.0
-        version: 1.39.0
+        specifier: 1.73.1
+        version: 1.73.1
       '@vscode/vsce':
         specifier: 2.19.0
         version: 2.19.0
@@ -2414,8 +2414,8 @@ packages:
     resolution: {integrity: sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==}
     dev: true
 
-  /@types/vscode@1.39.0:
-    resolution: {integrity: sha512-rlg0okXDt7NjAyHXbZ2nO1I/VY/8y9w67ltLRrOxXQ46ayvrYZavD4A6zpYrGbs2+ZOEQzcUs+QZOqcVGQIxXQ==}
+  /@types/vscode@1.73.1:
+    resolution: {integrity: sha512-eArfOrAoZVV+Ao9zQOCaFNaeXj4kTCD+bGS2gyNgIFZH9xVMuLMlRrEkhb22NyxycFWKV1UyTh03vhaVHmqVMg==}
     dev: true
 
   /@types/yargs-parser@21.0.0:


### PR DESCRIPTION
# Issue
Min supported Visual Studio Code version is old. 

## Description

Update min VSCode version to `1.73.1`.
Enables also the use of [Log output channel](https://code.visualstudio.com/updates/v1_73#_log-output-channel), see https://github.com/SAP/guided-answers-extension/pull/538

## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [x] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
