### PR TITLE
Fix #561: reuse/dep5 syntax

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -3,26 +3,26 @@ Upstream-Name: guided-answers-extension
 Upstream-Contact: sapfiorielements@sap.com
 Source: https://github.com/SAP/guided-answers-extension
 Disclaimer: The code in this project may include calls to APIs ("API Calls") of
-SAP or third-party products or services developed outside of this project
-("External Products").
-"APIs" means application programming interfaces, as well as their respective
-specifications and implementing code that allows software to communicate with
-other software.
-API Calls to External Products are not licensed under the open source license
-that governs this project. The use of such API Calls and related External
-Products are subject to applicable additional agreements with the relevant
-provider of the External Products. In no event shall the open source license
-that governs this project grant any rights in or to any External Products,or
-alter, expand or supersede any terms of the applicable additional agreements.
-If you have a valid license agreement with SAP for the use of a particular SAP
-External Product, then you may make use of any API Calls included in this
-project's code for that SAP External Product, subject to the terms of such
-license agreement. If you do not have a valid license agreement for the use of
-a particular SAP External Product, then you may only make use of any API Calls
-in this project for that SAP External Product for your internal, non-productive
-and non-commercial test and evaluation of such API Calls. Nothing herein grants
-you any rights to use or access any SAP External Product, or provide any third
-parties the right to use of access any SAP External Product, through API Calls.
+ SAP or third-party products or services developed outside of this project
+ ("External Products").
+ "APIs" means application programming interfaces, as well as their respective
+ specifications and implementing code that allows software to communicate with
+ other software.
+ API Calls to External Products are not licensed under the open source license
+ that governs this project. The use of such API Calls and related External
+ Products are subject to applicable additional agreements with the relevant
+ provider of the External Products. In no event shall the open source license
+ that governs this project grant any rights in or to any External Products,or
+ alter, expand or supersede any terms of the applicable additional agreements.
+ If you have a valid license agreement with SAP for the use of a particular SAP
+ External Product, then you may make use of any API Calls included in this
+ project's code for that SAP External Product, subject to the terms of such
+ license agreement. If you do not have a valid license agreement for the use of
+ a particular SAP External Product, then you may only make use of any API Calls
+ in this project for that SAP External Product for your internal, non-productive
+ and non-commercial test and evaluation of such API Calls. Nothing herein grants
+ you any rights to use or access any SAP External Product, or provide any third
+ parties the right to use of access any SAP External Product, through API Calls.
 
 Files: *
 Copyright: 2022 SAP SE


### PR DESCRIPTION
# Issue

#561 

## Description

This commit fixes the syntax of the file `.reuse/dep5`.

The check using the REUSE tool was failing with the error:
```
reuse.project - ERROR - .reuse/dep5 has syntax errors
```

The problem was missing whitespace or tab at the start of the so called "continuation lines":
> The lines after the first are called continuation lines and must start with a space or a tab.

Related issues:
- https://github.com/fsfe/reuse-tool/issues/829

Related links and references:
- https://reuse.software/spec/
- https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/#disclaimer-field
- https://www.debian.org/doc/debian-policy/ch-controlfields#syntax-of-control-files

## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [ ] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [ ] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
