### PR TITLE
chore: consume latest v2.1.1 of sonar cloud

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -46,7 +46,7 @@ jobs:
               run: pnpm run test
             - name: Run SonarCloud scan
               if: matrix.os == 'ubuntu-latest' && matrix.node-version == '18.x'
-              uses: sonarsource/sonarcloud-github-action@v2.1
+              uses: sonarsource/sonarcloud-github-action@v2.1.1
               env:
                   GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
# Issue

Follow up to PR #594 where v2.1 was consumed but I wanted to consume v2.1.1

## Description

_FILL IN DETAILS HERE_

## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [x] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
