### PR TITLE
fix: set document overflow style to prevent screen jump

### DIFF
--- a/.changeset/rare-parents-press.md
+++ b/.changeset/rare-parents-press.md
@@ -1,0 +1,5 @@
+---
+"@sap/guided-answers-extension-webapp": patch
+---
+
+Prevent screen jump when opening a dialog

--- a/packages/webapp/src/webview/ui/components/App/App.scss
+++ b/packages/webapp/src/webview/ui/components/App/App.scss
@@ -5,6 +5,9 @@ html {
     font-family: var(--vscode-font-family);
     -webkit-font-smoothing: antialiased;
 }
+body[role='document'] {
+    overflow: auto !important;
+}
 
 h1 {
     color: var(--vscode-settings-headerForeground);
@@ -70,7 +73,7 @@ h1 {
             margin-bottom: 10px;
             margin-top: 0px;
 
-            >i {
+            > i {
                 vertical-align: middle;
             }
         }


### PR DESCRIPTION
# Issue

#338 

## Description

Set document overflow to auto when dialog is open

## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [ ] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
