### PR TITLE
fix: update `actions/cache@v4.0.3`

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -24,7 +24,7 @@ jobs:
               with:
                   run_install: true
             - name: Cache pnpm modules
-              uses: actions/cache@v4
+              uses: actions/cache@v4.0.3
               env:
                   cache-name: cache-pnpm-modules
               with:
@@ -69,7 +69,7 @@ jobs:
               with:
                   run_install: true
             - name: Cache pnpm modules
-              uses: actions/cache@v4
+              uses: actions/cache@v4.0.3
               env:
                   cache-name: cache-pnpm-modules
               with:
@@ -113,7 +113,7 @@ jobs:
               with:
                   run_install: true
             - name: Cache pnpm modules
-              uses: actions/cache@v4
+              uses: actions/cache@v4.0.3
               env:
                   cache-name: cache-pnpm-modules
               with:


### PR DESCRIPTION
# Issue

Currently build issue appears to be connected to outdated `actions/cache` version.
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v4.0.2`
```
