### PR TITLE
fix:image url after backend update

### DIFF
--- a/.changeset/forty-buckets-rescue.md
+++ b/.changeset/forty-buckets-rescue.md
@@ -1,0 +1,6 @@
+---
+"@sap/guided-answers-extension-core": patch
+"sap-guided-answers-extension": patch
+---
+
+fix: image url after backend update

--- a/packages/core/src/guided-answers-api.ts
+++ b/packages/core/src/guided-answers-api.ts
@@ -30,7 +30,6 @@ const API_HOST = 'https://ga.support.sap.com';
 const VERSION = 'v6';
 const NODE_PATH = `/dtp/api/${VERSION}/nodes/`;
 const TREE_PATH = `/dtp/api/${VERSION}/trees/`;
-const IMG_PREFIX = '/dtp/viewer/';
 const FEEDBACK_COMMENT = `dtp/api/${VERSION}/feedback/comment`;
 const FEEDBACK_OUTCOME = `dtp/api/${VERSION}/feedback/outcome`;
 const DEFAULT_MAX_RESULTS = 9999;
@@ -90,7 +89,7 @@ function getConsoleLogger(): Logger {
  * @returns - html string with converted <img>-tags
  */
 function convertImageSrc(body: string, host: string): string {
-    return body.replace(/src="services\/backend\.xsjs\?/gi, `src="${host}${IMG_PREFIX}services/backend.xsjs?`);
+    return body.replace(/src="\/api\/viewer\/image\//gi, `src="${host}/api/viewer/image/`);
 }
 
 /**

--- a/packages/core/test/__snapshots__/guided-answers-api.test.ts.snap
+++ b/packages/core/test/__snapshots__/guided-answers-api.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Guided Answers Api: console logger Get node by id: Fallback to console 
 
 exports[`Guided Answers Api: getNodeById() Get node by id, node enhanced, should return enhanced node 1`] = `
 {
-  "BODY": "<p><span data-guided-answers-command-8d98638a0304b3f13b54d885dc542121="%7B%22label%22%3A%22what%20does%20that%20even%20mean%22%2C%22description%22%3A%22we%20decorate%20'Body%20of'%20with%20a%20link%20to%20vscode%20command%22%2C%22exec%22%3A%7B%22extensionId%22%3A%22terry.exxt%22%2C%22commandId%22%3A%22Knock%20kock%22%2C%22argument%22%3A%7B%22fsPath%22%3A%22whos%2Fthere%2Fbody%2Fof%22%7D%7D%7D">Body of</span> <span data-guided-answers-command-8d98638a0304b3f13b54d885dc542121="%7B%22label%22%3A%22of%20course%2C%2042%22%2C%22description%22%3A%22Text%20'solution%20to%20all%20questions'%20decorated%20as%20link%20to%20terminal%20command%22%2C%22exec%22%3A%7B%22arguments%22%3A%5B%22echo%22%2C%2242%22%5D%2C%22cwd%22%3A%22%22%7D%7D">solution to all questions</span> <img src="https://ga.support.sap.com/dtp/viewer/services/backend.xsjs?cmd=viewImage&amp;id=1" width="200" height="100" />&lt;script&gt;alert("evil");&lt;/script&gt;</p>",
+  "BODY": "<p><span data-guided-answers-command-8d98638a0304b3f13b54d885dc542121="%7B%22label%22%3A%22what%20does%20that%20even%20mean%22%2C%22description%22%3A%22we%20decorate%20'Body%20of'%20with%20a%20link%20to%20vscode%20command%22%2C%22exec%22%3A%7B%22extensionId%22%3A%22terry.exxt%22%2C%22commandId%22%3A%22Knock%20kock%22%2C%22argument%22%3A%7B%22fsPath%22%3A%22whos%2Fthere%2Fbody%2Fof%22%7D%7D%7D">Body of</span> <span data-guided-answers-command-8d98638a0304b3f13b54d885dc542121="%7B%22label%22%3A%22of%20course%2C%2042%22%2C%22description%22%3A%22Text%20'solution%20to%20all%20questions'%20decorated%20as%20link%20to%20terminal%20command%22%2C%22exec%22%3A%7B%22arguments%22%3A%5B%22echo%22%2C%2242%22%5D%2C%22cwd%22%3A%22%22%7D%7D">solution to all questions</span> <img src="https://ga.support.sap.com/api/viewer/image/9876" width="200" height="100" />&lt;script&gt;alert("evil");&lt;/script&gt;</p>",
   "COMMANDS": [
     {
       "description": "Node enhancement with terminal command",
@@ -123,7 +123,7 @@ exports[`Guided Answers Api: getNodeById() Get node by id, node enhanced, should
 
 exports[`Guided Answers Api: getNodeById() Get node by id, should return the node 1`] = `
 {
-  "BODY": "<p>Body of node 123 <img src="https://ga.support.sap.com/dtp/viewer/services/backend.xsjs?cmd=viewImage&amp;id=1" width="200" height="100" />&lt;script&gt;alert("evil");&lt;/script&gt;</p>",
+  "BODY": "<p>Body of node 123 <img src="https://ga.support.sap.com/api/viewer/image/1234" width="200" height="100" />&lt;script&gt;alert("evil");&lt;/script&gt;</p>",
   "EDGES": [
     {
       "LABEL": "Good",

--- a/packages/core/test/guided-answers-api.test.ts
+++ b/packages/core/test/guided-answers-api.test.ts
@@ -391,7 +391,7 @@ describe('Guided Answers Api: getNodeById()', () => {
         const data = {
             NODE_ID: 123,
             TITLE: 'Node',
-            BODY: `<p>Body of node 123 <img src="services/backend.xsjs?cmd=viewImage&amp;id=1" width="200" height="100" /><script>alert("evil");</script></p>`,
+            BODY: `<p>Body of node 123 <img src="/api/viewer/image/1234" width="200" height="100" /><script>alert("evil");</script></p>`,
             QUESTION: 'How are you?',
             EDGES: [
                 {
@@ -424,7 +424,7 @@ describe('Guided Answers Api: getNodeById()', () => {
         const data: GuidedAnswerNode = {
             NODE_ID: -1,
             TITLE: 'Forty-two',
-            BODY: `<p>Body of solution to all questions <img src="services/backend.xsjs?cmd=viewImage&amp;id=1" width="200" height="100" /><script>alert("evil");</script></p>`,
+            BODY: `<p>Body of solution to all questions <img src="/api/viewer/image/9876" width="200" height="100" /><script>alert("evil");</script></p>`,
             QUESTION: 'Answer to the Ultimate Question of Life, the Universe, and Everything',
             EDGES: [
                 {
@@ -681,7 +681,7 @@ describe('Guided Answers Api: getNodeById()', () => {
         mockedAxios.get.mockImplementation(() =>
             Promise.resolve({
                 data: {
-                    BODY: '<img src="services/backend.xsjs?no-extra-attributes" /><img width="321" src="services/backend.xsjs?with-attribute=width;height" height="123" /><img width="111" src="https://any.host/services/backend.xsjs?" height="222" />'
+                    BODY: '<img src="/api/viewer/image/any/thing/else" /><img width="321" src="/api/viewer/image/1" height="123" /><img width="111" src="/api/viewer/image/2" height="222" />'
                 }
             })
         );
@@ -691,7 +691,7 @@ describe('Guided Answers Api: getNodeById()', () => {
 
         //Result check
         expect(result.BODY).toBe(
-            '<img src="http://host/dtp/viewer/services/backend.xsjs?no-extra-attributes" /><img width="321" src="http://host/dtp/viewer/services/backend.xsjs?with-attribute=width;height" height="123" /><img width="111" src="https://any.host/services/backend.xsjs?" height="222" />'
+            '<img src="http://host/api/viewer/image/any/thing/else" /><img width="321" src="http://host/api/viewer/image/1" height="123" /><img width="111" src="http://host/api/viewer/image/2" height="222" />'
         );
     });
 

--- a/packages/ide-extension/test/bookmarks/bookmarks.test.ts
+++ b/packages/ide-extension/test/bookmarks/bookmarks.test.ts
@@ -23,7 +23,7 @@ const mockBookmarks: Bookmarks = {
             {
                 NODE_ID: 1,
                 TITLE: 'Forty-two',
-                BODY: `<p>Body of solution to all questions <img src="services/backend.xsjs?cmd=viewImage&amp;id=1" width="200" height="100" /><script>alert("evil");</script></p>`,
+                BODY: `<p>Body of solution to all questions <img src="/api/viewer/image/12345" width="200" height="100" /><script>alert("evil");</script></p>`,
                 QUESTION: 'Answer to the Ultimate Question of Life, the Universe, and Everything',
                 EDGES: [
                     {
@@ -50,7 +50,7 @@ const mockBookmarks: Bookmarks = {
             {
                 NODE_ID: 1,
                 TITLE: 'Forty-two',
-                BODY: `<p>Body of solution to all questions <img src="services/backend.xsjs?cmd=viewImage&amp;id=1" width="200" height="100" /><script>alert("evil");</script></p>`,
+                BODY: `<p>Body of solution to all questions <img src="/api/viewer/image/98765" width="200" height="100" /><script>alert("evil");</script></p>`,
                 QUESTION: 'Answer to the Ultimate Question of Life, the Universe, and Everything',
                 EDGES: [
                     {


### PR DESCRIPTION
# Issue
Images are not shown in Guided Answers extension:


## Description
Due to changes on the backend system, images are not shown
<img width="977" height="525" alt="image" src="https://github.com/user-attachments/assets/a8bd4988-e386-4856-ad69-4b4e566f22ac" />

With this pull request, the image URL is fixed:

<img width="1142" height="940" alt="image" src="https://github.com/user-attachments/assets/167f6980-87f6-4e98-aa33-e8afeff75ed8" />


## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/guided-answers-extension/blob/main/docs/developer-guide.md).
- [x] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
