### PR TITLE
chore: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                node-version: [18.x, 20.x]
+                node-version: [22.x, 24.x]
         runs-on: ${{ matrix.os }}
         permissions:
             contents: read
@@ -47,7 +47,7 @@ jobs:
             - name: Run unit tests
               run: pnpm run test
             - name: Run SonarCloud scan
-              if: matrix.os == 'ubuntu-latest' && matrix.node-version == '18.x'
+              if: matrix.os == 'ubuntu-latest' && matrix.node-version == '22.x'
               uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
               env:
                   GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
@@ -81,10 +81,10 @@ jobs:
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
                   restore-keys: |
                       ${{ runner.os }}-build-${{ env.cache-name }}-
-            - name: Use Node.js 18.x
+            - name: Use Node.js 22.x
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
-                  node-version: 18.x
+                  node-version: 22.x
             - name: Install pnpm modules
               run: pnpm install
             - name: Apply changesets
@@ -127,10 +127,10 @@ jobs:
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
                   restore-keys: |
                       ${{ runner.os }}-build-${{ env.cache-name }}-
-            - name: Use Node.js 18.x
+            - name: Use Node.js 22.x
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
-                  node-version: 18.x
+                  node-version: 22.x
             - name: Install pnpm modules
               run: pnpm install
             - name: Replace placeholder with instrumentation key

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,15 +18,15 @@ jobs:
         timeout-minutes: 15
         steps:
             - name: Checkout code repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
                   fetch-depth: 0
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
               with:
                   run_install: true
             - name: Cache pnpm modules
-              uses: actions/cache@v4
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               env:
                   cache-name: cache-pnpm-modules
               with:
@@ -35,7 +35,7 @@ jobs:
                   restore-keys: |
                       ${{ matrix.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Install pnpm modules
@@ -48,7 +48,7 @@ jobs:
               run: pnpm run test
             - name: Run SonarCloud scan
               if: matrix.os == 'ubuntu-latest' && matrix.node-version == '18.x'
-              uses: SonarSource/sonarqube-scan-action@v5
+              uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
               env:
                   GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -64,16 +64,16 @@ jobs:
             changes: ${{ steps.changesetVersion.outputs.changes }} # map step output to job output
         steps:
             - name: Checkout code repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
                   fetch-depth: 0
                   token: ${{ secrets.ACCESS_PAT }}
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
               with:
                   run_install: true
             - name: Cache pnpm modules
-              uses: actions/cache@v4
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               env:
                   cache-name: cache-pnpm-modules
               with:
@@ -82,7 +82,7 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-build-${{ env.cache-name }}-
             - name: Use Node.js 18.x
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 18.x
             - name: Install pnpm modules
@@ -113,13 +113,13 @@ jobs:
         needs: version
         steps:
             - name: Checkout code repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
               with:
                   run_install: true
             - name: Cache pnpm modules
-              uses: actions/cache@v4
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               env:
                   cache-name: cache-pnpm-modules
               with:
@@ -128,13 +128,13 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-build-${{ env.cache-name }}-
             - name: Use Node.js 18.x
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 18.x
             - name: Install pnpm modules
               run: pnpm install
             - name: Replace placeholder with instrumentation key
-              uses: jacobtomlinson/gha-find-replace@v3
+              uses: jacobtomlinson/gha-find-replace@f1069b438f125e5395d84d1c6fd3b559a7880cb5 # v3.0.5
               with:
                   include: packages/ide-extension/src/telemetry/telemetry.ts
                   find: 'ApplicationInsightsInstrumentationKeyPLACEH0LDER'
@@ -146,7 +146,7 @@ jobs:
               run: pnpm run ide-ext:package
             - name: Get version number from /packages/ide-extension/package.json
               id: package-version
-              uses: martinbeentjes/npm-get-version-action@main
+              uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b # v1.3.1
               with:
                   path: packages/ide-extension
             - name: Read last entry of changelog
@@ -155,7 +155,7 @@ jobs:
                   node -e 'require(`changelog-parser`)(`./packages/ide-extension/CHANGELOG.md`).then((c)=>console.log(c?.versions?.[0]?.body || `See CHANGELOG.md for details`))' >> $GITHUB_ENV
                   echo "END_CHANGEL0G_ENTRY" >> $GITHUB_ENV
             - name: Create Github Release
-              uses: softprops/action-gh-release@v1
+              uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
               with:
                   body: ${{ env.lastChangelogEntry }}
                   draft: false

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,6 +13,8 @@ jobs:
                 os: [ubuntu-latest, windows-latest]
                 node-version: [18.x, 20.x]
         runs-on: ${{ matrix.os }}
+        permissions:
+            contents: read
         timeout-minutes: 15
         steps:
             - name: Checkout code repository
@@ -55,6 +57,8 @@ jobs:
         # Run version job only on pushes to the main branch. The job depends on completion of the build job.
         if: github.repository == 'SAP/guided-answers-extension' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         needs: build
         outputs:
             changes: ${{ steps.changesetVersion.outputs.changes }} # map step output to job output
@@ -104,6 +108,8 @@ jobs:
         # This job needs to run after the version job commit has been merged - so check if that step returns 'false'
         if: github.repository == 'SAP/guided-answers-extension' && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.version.outputs.changes == 'false'
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         needs: version
         steps:
             - name: Checkout code repository

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -9,6 +9,8 @@ on:
 jobs:
     reuse-lint:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - uses: actions/checkout@v4
             - name: REUSE Compliance Check


### PR DESCRIPTION
## Summary

Adds explicit `permissions:` blocks to all affected GitHub Actions jobs to comply with GitHub's requirement for explicit workflow permissions before **June 10, 2026**.

- `build`: `contents: read` — checkout and test only, no writes needed
- `version`: `contents: read` — git push uses `ACCESS_PAT` (not `GITHUB_TOKEN`), so GITHUB_TOKEN only needs read
- `release`: `contents: write` — required by `softprops/action-gh-release` to create GitHub releases
- `reuse-lint`: `contents: read` — checkout and compliance check only

## Test plan

- [ ] Verify CI pipeline passes on this PR (`build` job)
- [ ] Confirm `release` job can still create GitHub releases after merge (next release cycle)