### PR TITLE
ci: use ci-secrets environment and pin handlebars

### DIFF
--- a/.changeset/thirty-parrots-call.md
+++ b/.changeset/thirty-parrots-call.md
@@ -1,0 +1,8 @@
+---
+'@sap/guided-answers-extension-core': patch
+'sap-guided-answers-extension': patch
+'@sap/guided-answers-extension-types': patch
+'@sap/guided-answers-extension-webapp': patch
+---
+
+bump version of handlebars as transient devdependency of ts-jest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
     build:
+        environment: ci-secrets
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest]
@@ -57,6 +58,7 @@ jobs:
         # Run version job only on pushes to the main branch. The job depends on completion of the build job.
         if: github.repository == 'SAP/guided-answers-extension' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
+        environment: ci-secrets
         permissions:
             contents: read
         needs: build
@@ -108,6 +110,7 @@ jobs:
         # This job needs to run after the version job commit has been merged - so check if that step returns 'false'
         if: github.repository == 'SAP/guided-answers-extension' && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.version.outputs.changes == 'false'
         runs-on: ubuntu-latest
+        environment: ci-secrets
         permissions:
             contents: write
         needs: version

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "prettier": "3.6.2",
         "pretty-quick": "4.2.2",
         "rimraf": "5.0.10",
-        "ts-jest": "29.4.1",
+        "ts-jest": "29.4.11",
         "ts-node": "10.9.2",
         "typescript": "4.9.5"
     },
@@ -51,7 +51,8 @@
     "packageManager": "pnpm@8.15.9",
     "pnpm": {
         "overrides": {
-            "cross-spawn": ">=7.0.5"
+            "cross-spawn": ">=7.0.5",
+            "handlebars": ">=4.7.9"
         }
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   cross-spawn: '>=7.0.5'
+  handlebars: '>=4.7.9'
 
 importers:
 
@@ -81,8 +82,8 @@ importers:
         specifier: 5.0.10
         version: 5.0.10
       ts-jest:
-        specifier: 29.4.1
-        version: 29.4.1(@babel/core@7.26.9)(jest@29.7.0)(typescript@4.9.5)
+        specifier: 29.4.11
+        version: 29.4.11(@babel/core@7.26.9)(jest@29.7.0)(typescript@4.9.5)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@types/node@18.19.6)(typescript@4.9.5)
@@ -872,7 +873,7 @@ packages:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
     dev: true
 
   /@changesets/assemble-release-plan@6.0.9:
@@ -883,7 +884,7 @@ packages:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.1
+      semver: 7.7.2
     dev: true
 
   /@changesets/changelog-git@0.2.1:
@@ -952,7 +953,7 @@ packages:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.1
+      semver: 7.7.2
     dev: true
 
   /@changesets/get-release-plan@4.0.13:
@@ -3044,7 +3045,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.7.1
+      semver: 7.7.2
       ts-api-utils: 1.4.3(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -3064,7 +3065,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@4.9.5)
       eslint: 8.57.1
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5669,8 +5670,8 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
-  /handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  /handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
     dependencies:
@@ -6017,7 +6018,7 @@ packages:
   /is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
     dev: true
 
   /is-callable@1.2.7:
@@ -6264,7 +6265,7 @@ packages:
       '@babel/parser': 7.26.9
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6711,7 +6712,7 @@ packages:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7216,7 +7217,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
     dev: true
 
   /make-error@1.3.6:
@@ -7441,7 +7442,7 @@ packages:
     engines: {node: '>=10'}
     requiresBuild: true
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
     dev: true
     optional: true
 
@@ -7478,7 +7479,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.16.1
-      semver: 7.7.1
+      semver: 7.7.2
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -8026,7 +8027,6 @@ packages:
       prop-types: 15.8.1
       react: 16.14.0
       scheduler: 0.19.1
-    bundledDependencies: false
 
   /react-i18next@13.2.2(i18next@23.7.16)(react-dom@16.14.0)(react@16.14.0):
     resolution: {integrity: sha512-+nFUkbRByFwnrfDcYqvzBuaeZb+nACHx+fAWN/pZMddWOCJH5hoc21+Sa/N/Lqi6ne6/9wC/qRGOoQhJa6IkEQ==}
@@ -8183,7 +8183,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.8.1
-    bundledDependencies: false
 
   /read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -8525,6 +8524,12 @@ packages:
 
   /semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
+  /semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
     hasBin: true
     dev: true
@@ -9107,8 +9112,8 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /ts-jest@29.4.1(@babel/core@7.26.9)(jest@29.7.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==}
+  /ts-jest@29.4.11(@babel/core@7.26.9)(jest@29.7.0)(typescript@4.9.5):
+    resolution: {integrity: sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -9119,7 +9124,7 @@ packages:
       esbuild: '*'
       jest: ^29.0.0 || ^30.0.0
       jest-util: ^29.0.0 || ^30.0.0
-      typescript: '>=4.3 <6'
+      typescript: '>=4.3 <7'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -9137,12 +9142,12 @@ packages:
       '@babel/core': 7.26.9
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       jest: 29.7.0(@types/node@18.19.6)(ts-node@10.9.2)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.7.2
+      semver: 7.8.4
       type-fest: 4.41.0
       typescript: 4.9.5
       yargs-parser: 21.1.1


### PR DESCRIPTION
## Summary

- Add `environment: ci-secrets` to the `build`, `version`, and `release` jobs in `pipeline.yml` so secrets are sourced from the GitHub environment
- Pin `handlebars` to `>=4.7.9` via pnpm override to resolve the critical advisory (CVE GHSA-2w6w-674q-4c4q)

## Test plan

- [ ] Verify the pipeline runs successfully on this PR with secrets resolved from the `ci-secrets` environment
- [ ] Confirm SonarCloud scan (build job, ubuntu/22.x) completes without auth errors
- [ ] Confirm no `handlebars` critical advisory appears in `pnpm audit`